### PR TITLE
Harden installer display setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Dieses Projekt stellt eine komplett verwaltete Slideshow-Anwendung für den Rasp
 - **Automatisierte Wiedergabe** von Bildern und Videos über `mpv` (optional `feh` bzw. `omxplayer`), inklusive Infobildschirm bei Leerlauf.
 - **Flexible Bilddarstellung**: Bilddauer, Skalierung (einpassen, strecken, Originalgröße), Rotation und Übergänge (Fade oder Slide) werden im Webinterface eingestellt.
 - **Mehrere Medienquellen**: lokale Ordner oder SMB/CIFS-Freigaben, die automatisch eingehängt und in regelmäßigen Abständen gescannt werden.
+- **Komfortable SMB-Einrichtung**: Freigaben lassen sich direkt per UNC-Pfad (z. B. `\\192.168.150.10\Software\RPI-Test\1`) inklusive optionaler Domänen-Anmeldung hinzufügen.
 - **Splitscreen-Modus**: Optional lassen sich zwei Quellen parallel darstellen – z. B. Videos links und Bilder rechts – inklusive unabhängiger Wiedergabeschleifen.
 - **Automatischer Medienabgleich**: Neue Dateien in überwachten Ordnern werden ohne Neustart erkannt und automatisch in der Wiedergabe berücksichtigt.
 - **Weboberfläche** mit Dashboard zur Anzeige der aktuell wiedergegebenen Datei, Verwaltung der Playlist, Netzwerk- und Systemeinstellungen sowie Update- und Service-Steuerung.
@@ -43,7 +44,8 @@ pyproject.toml       # Python-Abhängigkeiten (Poetry)
 
 ## Voraussetzungen
 
-- Raspberry Pi OS (Bookworm oder Bullseye) mit Desktop-Komponenten.
+- Raspberry Pi OS (Bookworm oder Bullseye) – wahlweise mit Desktop (X11) oder als Lite-Variante. Für headless-Geräte stellt der
+  Installer über `--drm` automatisch auf den DRM/Framebuffer-Modus um.
 - Internetzugang, damit das Installationsskript Repository und Pakete aus dem Netz beziehen kann.
 - Optional: SMB-Freigaben, falls Netzlaufwerke eingebunden werden sollen.
 
@@ -62,11 +64,22 @@ pyproject.toml       # Python-Abhängigkeiten (Poetry)
    curl -sSL https://raw.githubusercontent.com/joni123467/Slideshow/refs/heads/main/scripts/install.sh | sudo bash
    ```
 
-2. Das Skript richtet automatisch alle Abhängigkeiten (inklusive `mpv`, `ffmpeg`, `feh`, `cifs-utils`) ein, ermittelt den neuesten Branch im Format `version-x.y.z`, klont diesen unter `/opt/slideshow` und legt dabei einen dedizierten Dienstbenutzer an. Benutzername und Passwort können während der Installation angepasst werden:
+2. Das Skript richtet automatisch alle Abhängigkeiten (inklusive `mpv`, `ffmpeg`, `feh`, `cifs-utils`) ein, ermittelt den neuesten Branch im Format `version-x.y.z`, klont diesen unter `/opt/slideshow` und legt dabei einen dedizierten Dienstbenutzer an. Damit die Hardwarebeschleunigung funktioniert, wird der Account – sofern die Gruppen existieren – direkt `video`, `render` und `input` hinzugefügt. Benutzername und Passwort können während der Installation angepasst werden:
 
    ```bash
    sudo ./install.sh
    ```
+
+   Für Installationen ohne Desktop (Raspberry Pi OS Lite) empfiehlt sich der DRM-Modus:
+
+   ```bash
+   sudo ./install.sh --drm
+   ```
+
+   Weitere Optionen:
+
+   - `--video-backend x11|drm` setzt das Backend explizit.
+   - `--desktop-user <name>` hinterlegt direkt den Benutzer, dessen X11-Sitzung verwendet werden soll.
 
 3. Nach erfolgreicher Installation läuft der Dienst als `slideshow.service`. Der Code liegt unter `/opt/slideshow`, ein virtuelles Python-Environment befindet sich in `/opt/slideshow/.venv`. Zusätzlich erzeugt der Installer einen Eintrag unter `/etc/sudoers.d/slideshow`, damit der Dienstbenutzer Updates, Dienststeuerung, Neustarts sowie das SMB-Helferskript ohne Passwort ausführen kann.
 
@@ -98,7 +111,44 @@ Für lokale Entwicklung kann der Server manuell gestartet werden:
 python manage.py run
 ```
 
+Vor dem ersten Start sollten alle Python-Abhängigkeiten installiert werden – entweder über Poetry (`poetry install`) oder klassisch mit `pip install -r requirements.txt`. Dadurch steht unter anderem das Paket `flask-login` bereit, das für die Webanmeldung benötigt wird.
+
 Standardmäßig wird dabei der Flask-Debug-Server auf Port `8080` im lokalen Netzwerk erreichbar.
+
+### Datenablage konfigurieren
+
+Die Anwendung legt Konfigurations- und Statusdateien in einem beschreibbaren Datenverzeichnis ab. Standardmäßig wird dafür `~/.slideshow` verwendet. Über die Umgebungsvariable `SLIDESHOW_DATA_DIR` kann ein alternatives Verzeichnis angegeben werden:
+
+```bash
+export SLIDESHOW_DATA_DIR=/var/lib/slideshow
+python manage.py run
+```
+
+Ist das angegebene Verzeichnis nicht beschreibbar, fällt die Anwendung automatisch auf das Verzeichnis im Benutzerprofil (`~/.slideshow`) zurück.
+
+### Medienquellen und SMB-Mounts
+
+- Der lokale Medienordner (`local`-Quelle) wird beim ersten Start automatisch erzeugt. Im Standarddatenspeicher liegt er unter `<Datenverzeichnis>/media`.
+- Für SMB-Freigaben legt die Anwendung einen beschreibbaren Mount-Root unter `<Datenverzeichnis>/mounts` an. Neue Freigaben werden automatisch dort eingeordnet; bestehende Konfigurationen mit dem alten Standardpfad `/mnt/slideshow/<name>` werden beim nächsten Start migriert, falls sie nicht mehr erreichbar oder beschreibbar sind.
+- Die Weboberfläche erlaubt nun, automatische Scans pro Quelle ein- oder auszuschalten sowie nicht mehr benötigte SMB-Quellen zu löschen. SMB-Freigaben werden ausschließlich über ihren UNC-Pfad (z. B. `\\\\server\\share\\bilder`) angelegt; optionale Unterordner lassen sich direkt im Pfad angeben.
+
+### Zugriff auf die grafische Oberfläche
+
+- Der systemd-Dienst benötigt Zugriff auf die laufende Desktop-Sitzung (`DISPLAY=:0`). Während der Installation kann optional ein vorhandener Desktop-Benutzer angegeben werden. Dessen `.Xauthority` wird nicht mehr einmalig kopiert, sondern vor jedem Dienststart über `scripts/prestart.sh` synchronisiert, damit neue Login-Tokens automatisch übernommen werden.
+- Findet der Installer keine `.Xauthority`, weist er darauf hin. In diesem Fall muss entweder der korrekte Desktop-Benutzer ausgewählt oder die Datei manuell bereitgestellt werden. Alternativ lässt sich die Anwendung ohne Desktop im DRM-Modus betreiben.
+- Damit die Wiedergabe auf die Grafikhardware zugreifen kann, nimmt das Installationsskript den Dienstnutzer automatisch in die Gruppen `video`, `render` und `input` auf (sofern vorhanden). Fehlende Gruppen werden am Ende der Installation gemeldet.
+- Der systemd-Dienst verwendet `RuntimeDirectory=slideshow-<UID>` und setzt `XDG_RUNTIME_DIR` automatisch auf `/run/slideshow-<UID>`. Dadurch steht der notwendige Socket-Pfad auch nach einem Neustart ohne manuelle Eingriffe bereit.
+- Das Pre-Start-Skript wartet in mehreren Versuchen (`xset q`), bis die grafische Sitzung verfügbar ist. Gelingt dies nicht rechtzeitig, wird lediglich eine Warnung protokolliert – der Dienst startet weiter und versucht später erneut, das Display zu erreichen.
+
+### Headless- und DRM-Betrieb
+
+- Über `install.sh --drm` oder die Umgebungsvariable `SLIDESHOW_VIDEO_BACKEND=drm` richtet der Dienst automatisch den DRM-/Framebuffer-Modus ein. Ein Desktop-Benutzer ist dann nicht erforderlich; die Wiedergabe erfolgt direkt über `mpv --gpu-context=drm`.
+- Die Wiedergabeeinstellungen im Webinterface enthalten Auswahlfelder für Video- und Bild-Backend (`auto`, `x11`, `drm`) sowie zusätzliche Argumentlisten. Im Automatikmodus erkennt die Anwendung anhand der gesetzten Umgebungsvariablen bzw. eines vorhandenen `DISPLAY`, welches Backend verwendet werden soll.
+- Für Desktop-Systeme wartet der systemd-Dienst beim Start auf eine erreichbare X11-Sitzung (`xset q`). Dadurch werden Timing-Probleme beim Booten vermieden, wenn der Display-Manager länger benötigt.
+
+### Updates ohne Git-Checkout
+
+Wird die Anwendung als Paket ohne `.git`-Verzeichnis ausgeliefert, blendet die Update-Seite den Branch-Wechsler aus und verweist stattdessen auf die veröffentlichten Branches des GitHub-Repositories (`https://github.com/joni123467/Slideshow`). Sobald ein Git-Checkout verfügbar ist, erscheinen die Branches wie gewohnt in der Auswahl.
 
 ## Sicherheitshinweise
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask>=2.2,<3.0
+flask-login>=0.6,<0.7
+pyyaml>=6.0,<7.0
+watchdog>=3.0,<4.0
+simplepam>=0.1.5,<0.2
+pillow>=11.0,<12.0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,53 @@ set -euo pipefail
 
 # REPO_SLUG: joni123467/Slideshow
 
+usage() {
+  cat <<'EOF'
+Verwendung: install.sh [--drm] [--video-backend NAME] [--desktop-user NAME]
+
+Optionen:
+  --drm                Aktiviert die Framebuffer-/DRM-Ausgabe (kein Desktop erforderlich).
+  --video-backend NAME Setzt das Backend explizit auf "x11" oder "drm".
+  --desktop-user NAME  Überschreibt den Desktop-Benutzer für die X11-Anbindung.
+  --help               Zeigt diese Hilfe an.
+EOF
+}
+
+VIDEO_BACKEND="${SLIDESHOW_VIDEO_BACKEND:-x11}"
+DESKTOP_USER_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --drm)
+      VIDEO_BACKEND="drm"
+      shift
+      ;;
+    --video-backend)
+      VIDEO_BACKEND="${2:-}"
+      shift 2 || { echo "--video-backend benötigt einen Wert" >&2; exit 1; }
+      ;;
+    --desktop-user)
+      DESKTOP_USER_ARG="${2:-}"
+      shift 2 || { echo "--desktop-user benötigt einen Wert" >&2; exit 1; }
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unbekannte Option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+VIDEO_BACKEND="${VIDEO_BACKEND,,}"
+if [[ "$VIDEO_BACKEND" != "drm" && "$VIDEO_BACKEND" != "x11" ]]; then
+  echo "Unbekanntes Backend '$VIDEO_BACKEND', verwende x11." >&2
+  VIDEO_BACKEND="x11"
+fi
+
 APP_DIR="/opt/slideshow"
 VENV_DIR="$APP_DIR/.venv"
 SERVICE_FILE="/etc/systemd/system/slideshow.service"
@@ -12,13 +59,22 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
+echo "Installationsmodus: Backend=$VIDEO_BACKEND"
+
 REPO_SLUG=$(grep -m1 '^# REPO_SLUG:' "$0" | awk -F':' '{print $2}' | xargs)
 REPO_SLUG="${REPO_SLUG:-${SLIDESHOW_REPO_SLUG:-joni123467/Slideshow}}"
 REPO_URL="https://github.com/${REPO_SLUG}.git"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y git python3 python3-venv python3-pip rsync cifs-utils ffmpeg mpv feh curl ca-certificates
+COMMON_PACKAGES=(git python3 python3-venv python3-pip rsync cifs-utils ffmpeg mpv feh curl ca-certificates)
+EXTRA_PACKAGES=()
+if [[ "$VIDEO_BACKEND" == "x11" ]]; then
+  EXTRA_PACKAGES+=(x11-xserver-utils)
+else
+  EXTRA_PACKAGES+=(mesa-utils libdrm2 libgbm1)
+fi
+apt-get install -y "${COMMON_PACKAGES[@]}" "${EXTRA_PACKAGES[@]}"
 
 determine_latest_branch() {
   local url="$1"
@@ -73,6 +129,48 @@ fi
 
 echo "$USER_NAME:$USER_PASSWORD" | chpasswd
 
+GROUP_ADDED=()
+GROUP_MISSING=()
+for supplemental_group in video render input; do
+  if getent group "$supplemental_group" >/dev/null 2>&1; then
+    if id -nG "$USER_NAME" | tr ' ' '\n' | grep -qx "$supplemental_group"; then
+      continue
+    fi
+    usermod -aG "$supplemental_group" "$USER_NAME"
+    GROUP_ADDED+=("$supplemental_group")
+  else
+    GROUP_MISSING+=("$supplemental_group")
+  fi
+done
+
+USER_UID="$(id -u "$USER_NAME")"
+SERVICE_HOME="$(getent passwd "$USER_NAME" | cut -d: -f6)"
+if [[ -z "$SERVICE_HOME" ]]; then
+  echo "Konnte Home-Verzeichnis für $USER_NAME nicht bestimmen." >&2
+  exit 1
+fi
+
+DEFAULT_DESKTOP_USER="${SLIDESHOW_DESKTOP_USER:-${SUDO_USER:-}}"
+if [[ -n "$DESKTOP_USER_ARG" ]]; then
+  DESKTOP_USER="$DESKTOP_USER_ARG"
+else
+  if [[ -n "$DEFAULT_DESKTOP_USER" ]]; then
+    read -rp "Desktop-Benutzer für Anzeige [$DEFAULT_DESKTOP_USER]: " DESKTOP_USER_INPUT
+    DESKTOP_USER="${DESKTOP_USER_INPUT:-$DEFAULT_DESKTOP_USER}"
+  else
+    if [[ "$VIDEO_BACKEND" == "drm" ]]; then
+      read -rp "Desktop-Benutzer für Anzeige (leer lassen für headless): " DESKTOP_USER_INPUT
+    else
+      read -rp "Desktop-Benutzer für Anzeige (leer = keiner): " DESKTOP_USER_INPUT
+    fi
+    DESKTOP_USER="${DESKTOP_USER_INPUT:-}"
+  fi
+fi
+
+if [[ "$VIDEO_BACKEND" == "drm" && -z "$DESKTOP_USER" ]]; then
+  echo "DRM-Modus ohne Desktop-Benutzer: X11-Anbindung wird übersprungen."
+fi
+
 rm -rf "$APP_DIR"
 mkdir -p "$APP_DIR"
 
@@ -82,11 +180,12 @@ cat <<BRANCH > "$APP_DIR/.install_branch"
 $BRANCH
 BRANCH
 
-chmod +x "$APP_DIR/scripts/update.sh" "$APP_DIR/scripts/mount_smb.sh" 2>/dev/null || true
+chmod +x "$APP_DIR/scripts/update.sh" "$APP_DIR/scripts/mount_smb.sh" "$APP_DIR/scripts/prestart.sh" 2>/dev/null || true
 
 SUDOERS_FILE="/etc/sudoers.d/slideshow"
 SYSTEMCTL_BIN="$(command -v systemctl || echo /bin/systemctl)"
 REBOOT_BIN="$(command -v reboot || echo /sbin/reboot)"
+POWEROFF_BIN="$(command -v poweroff || echo /sbin/poweroff)"
 cat <<SUDOERS > "$SUDOERS_FILE"
 $USER_NAME ALL=(root) NOPASSWD: $APP_DIR/scripts/update.sh *
 $USER_NAME ALL=(root) NOPASSWD: $APP_DIR/scripts/mount_smb.sh *
@@ -95,6 +194,7 @@ $USER_NAME ALL=(root) NOPASSWD: $SYSTEMCTL_BIN start slideshow.service
 $USER_NAME ALL=(root) NOPASSWD: $SYSTEMCTL_BIN stop slideshow.service
 $USER_NAME ALL=(root) NOPASSWD: $SYSTEMCTL_BIN restart slideshow.service
 $USER_NAME ALL=(root) NOPASSWD: $REBOOT_BIN
+$USER_NAME ALL=(root) NOPASSWD: $POWEROFF_BIN
 SUDOERS
 chmod 440 "$SUDOERS_FILE"
 
@@ -107,31 +207,103 @@ elif [[ -f "$APP_DIR/requirements.txt" ]]; then
   "$VENV_DIR/bin/pip" install -r "$APP_DIR/requirements.txt"
 fi
 
-cat <<SERVICE > "$SERVICE_FILE"
-[Unit]
-Description=Slideshow Service
-After=network.target
+DESKTOP_HOME=""
+XAUTHORITY_PATH="$SERVICE_HOME/.Xauthority"
+XAUTHORITY_SOURCE=""
+XAUTHORITY_WARNING=0
+if [[ -n "$DESKTOP_USER" ]]; then
+  DESKTOP_HOME="$(getent passwd "$DESKTOP_USER" | cut -d: -f6)"
+  if [[ -z "$DESKTOP_HOME" ]]; then
+    echo "Hinweis: Desktop-Benutzer $DESKTOP_USER wurde nicht gefunden."
+    DESKTOP_USER=""
+  elif [[ -f "$DESKTOP_HOME/.Xauthority" ]]; then
+    XAUTHORITY_SOURCE="$DESKTOP_HOME/.Xauthority"
+    echo "Xauthority von $DESKTOP_USER wird beim Dienststart synchronisiert."
+  else
+    echo "WARNUNG: Keine .Xauthority bei $DESKTOP_USER gefunden."
+    XAUTHORITY_WARNING=1
+  fi
+fi
 
-[Service]
-Type=simple
-User=$USER_NAME
-WorkingDirectory=$APP_DIR
-Environment=PYTHONUNBUFFERED=1
-ExecStart=$VENV_DIR/bin/python manage.py run --host 0.0.0.0 --port 8080
-Restart=on-failure
+if [[ -z "$XAUTHORITY_SOURCE" && -n "$DESKTOP_USER" ]]; then
+  XAUTHORITY_WARNING=1
+fi
 
-[Install]
-WantedBy=multi-user.target
-SERVICE
+RUNTIME_NAME="slideshow-$USER_UID"
+RUNTIME_DIR="/run/$RUNTIME_NAME"
+
+UNIT_AFTER="After=network-online.target"
+UNIT_WANTS=("Wants=network-online.target")
+UNIT_INSTALL="WantedBy=multi-user.target"
+SERVICE_ENV=(
+  "Environment=PYTHONUNBUFFERED=1"
+  "Environment=XDG_RUNTIME_DIR=$RUNTIME_DIR"
+  "Environment=SLIDESHOW_SERVICE_USER=$USER_NAME"
+  "Environment=SLIDESHOW_VIDEO_BACKEND=$VIDEO_BACKEND"
+  "Environment=SLIDESHOW_IMAGE_BACKEND=$VIDEO_BACKEND"
+)
+if [[ -n "$XAUTHORITY_SOURCE" ]]; then
+  SERVICE_ENV+=("Environment=SLIDESHOW_XAUTHORITY_SOURCE=$XAUTHORITY_SOURCE")
+fi
+if [[ -n "$DESKTOP_USER" ]]; then
+  UNIT_AFTER+=" graphical.target"
+  UNIT_WANTS+=("Wants=graphical.target")
+  UNIT_INSTALL="WantedBy=graphical.target"
+  SERVICE_ENV+=("Environment=DISPLAY=:0" "Environment=XAUTHORITY=$XAUTHORITY_PATH")
+fi
+
+{
+  echo "[Unit]"
+  echo "Description=Slideshow Service"
+  echo "$UNIT_AFTER"
+  for want in "${UNIT_WANTS[@]}"; do
+    echo "$want"
+  done
+  echo ""
+  echo "[Service]"
+  echo "Type=simple"
+  echo "User=$USER_NAME"
+  echo "WorkingDirectory=$APP_DIR"
+  echo "RuntimeDirectory=$RUNTIME_NAME"
+  echo "PermissionsStartOnly=yes"
+  for env in "${SERVICE_ENV[@]}"; do
+    echo "$env"
+  done
+  echo "ExecStartPre=$APP_DIR/scripts/prestart.sh"
+  echo "ExecStart=$VENV_DIR/bin/python manage.py run --host 0.0.0.0 --port 8080"
+  echo "ExecStartPost=/bin/sh -c 'if [ -n \"\$DISPLAY\" ]; then echo \"Slideshow mit DISPLAY=\$DISPLAY gestartet (Backend: \$SLIDESHOW_VIDEO_BACKEND)\" | systemd-cat -t slideshow; else echo \"Slideshow im Headless-Modus gestartet\" | systemd-cat -t slideshow; fi'"
+  echo "Restart=on-failure"
+  echo "RestartSec=5"
+  echo ""
+  echo "[Install]"
+  echo "$UNIT_INSTALL"
+} > "$SERVICE_FILE"
 
 systemctl daemon-reload
 systemctl enable --now slideshow.service
 
 chown -R "$USER_NAME":"$USER_NAME" "$APP_DIR"
 
+GROUP_SUMMARY="Keine zusätzlichen Gruppen ergänzt."
+if [[ ${#GROUP_ADDED[@]} -gt 0 ]]; then
+  GROUP_SUMMARY="Dienstbenutzer zu folgenden Geräte-Gruppen hinzugefügt: ${GROUP_ADDED[*]}"
+fi
+GROUP_MISSING_NOTICE=""
+if [[ ${#GROUP_MISSING[@]} -gt 0 ]]; then
+  GROUP_MISSING_NOTICE="Fehlende Systemgruppen bitte manuell prüfen: ${GROUP_MISSING[*]}"
+fi
+
+if [[ "$XAUTHORITY_WARNING" -eq 1 ]]; then
+  echo "WARNUNG: Keine gültige Xauthority-Datei gefunden. Stellen Sie sicher, dass $USER_NAME Zugriff auf die grafische Sitzung hat (DISPLAY=:0)."
+fi
+
 cat <<INFO
 Installation abgeschlossen.
 Repository: $REPO_URL
 Branch: $BRANCH
 Dienstbenutzer: $USER_NAME
+Video-Backend: $VIDEO_BACKEND
+Desktop-Anzeige: ${DESKTOP_USER:-keine}
+$GROUP_SUMMARY
+${GROUP_MISSING_NOTICE:-}
 INFO

--- a/scripts/prestart.sh
+++ b/scripts/prestart.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[slideshow-prestart] $*" >&2
+}
+
+SERVICE_USER="${SLIDESHOW_SERVICE_USER:-}"
+if [[ -z "$SERVICE_USER" ]]; then
+  SERVICE_USER="$(id -un)"
+fi
+
+if [[ -n "${SLIDESHOW_XAUTHORITY_SOURCE:-}" && -n "${XAUTHORITY:-}" ]]; then
+  if [[ -f "$SLIDESHOW_XAUTHORITY_SOURCE" ]]; then
+    install -m 600 -o "$SERVICE_USER" -g "$SERVICE_USER" "$SLIDESHOW_XAUTHORITY_SOURCE" "$XAUTHORITY"
+    log "Xauthority von $SLIDESHOW_XAUTHORITY_SOURCE nach $XAUTHORITY synchronisiert."
+  else
+    log "Warnung: Xauthority-Quelle $SLIDESHOW_XAUTHORITY_SOURCE wurde nicht gefunden."
+  fi
+fi
+
+if [[ -z "${DISPLAY:-}" ]]; then
+  log "Kein DISPLAY gesetzt – headless Start."
+  exit 0
+fi
+
+if ! command -v xset >/dev/null 2>&1; then
+  log "xset nicht verfügbar – überspringe Anzeigeprüfung."
+  exit 0
+fi
+
+CHECK_OK=0
+for _ in $(seq 1 15); do
+  if command -v runuser >/dev/null 2>&1; then
+    if runuser -u "$SERVICE_USER" -- env DISPLAY="$DISPLAY" XAUTHORITY="${XAUTHORITY:-}" xset q >/dev/null 2>&1; then
+      CHECK_OK=1
+      break
+    fi
+  elif command -v su >/dev/null 2>&1; then
+    if su -s /bin/sh "$SERVICE_USER" -c "DISPLAY='$DISPLAY' XAUTHORITY='${XAUTHORITY:-}' xset q" >/dev/null 2>&1; then
+      CHECK_OK=1
+      break
+    fi
+  else
+    log "Weder runuser noch su verfügbar – überspringe Anzeigeprüfung."
+    CHECK_OK=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ "$CHECK_OK" -eq 1 ]]; then
+  log "Display $DISPLAY ist erreichbar."
+else
+  log "Display $DISPLAY blieb unerreichbar; Dienst startet dennoch."
+fi
+
+exit 0

--- a/slideshow/app.py
+++ b/slideshow/app.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import functools
 import logging
 import subprocess
-from typing import Optional
+from typing import List, Optional
 
 from flask import Flask, Response, abort, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import LoginManager, current_user, login_required, login_user, logout_user
 
 from . import __version__
 from .auth import PamAuthenticator, User
-from .config import AppConfig, PlaylistItem
+from .config import AppConfig
 from .logging_config import available_logs
 from .media import MediaManager
 from .network import NetworkManager
@@ -99,46 +99,72 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     @pam_required
     def dashboard():
         state = get_state()
-        sources = media_manager.list_sources()
-        auto_totals = dict(
-            sorted(
-                (
-                    (source.name, len(media_manager.scan_directory(source)))
-                    for source in sources
-                    if source.auto_scan
-                ),
-                key=lambda item: item[0],
-            )
-        )
-        branches = system_manager.list_branches()
-        current_branch = system_manager.current_branch()
+        playlist_preview = media_manager.build_playlist()
         service_status = system_manager.service_status()
         return render_template(
             "dashboard.html",
             state=state,
-            playlist=media_manager.list_playlist(),
+            playlist=playlist_preview,
+            config=cfg,
+            service_status=service_status,
+        )
+
+    @app.route("/media")
+    @pam_required
+    def media_settings():
+        sources = media_manager.list_sources()
+        auto_totals = {}
+        for source in sources:
+            if not source.auto_scan:
+                continue
+            try:
+                media_manager.mount_source(source)
+                auto_totals[source.name] = len(media_manager.scan_directory(source))
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.warning("Automatischer Scan für %s fehlgeschlagen: %s", source.name, exc)
+                flash(f"Konnte Quelle {source.name} nicht einlesen: {exc}", "danger")
+        auto_totals = dict(sorted(auto_totals.items(), key=lambda item: item[0]))
+        return render_template(
+            "media.html",
             sources=sources,
+            auto_totals=auto_totals,
+            config=cfg,
+        )
+
+    @app.route("/playback")
+    @pam_required
+    def playback_settings_page():
+        sources = media_manager.list_sources()
+        return render_template(
+            "playback.html",
+            config=cfg,
+            sources=sources,
+            state=get_state(),
+        )
+
+    @app.route("/network")
+    @pam_required
+    def network_settings():
+        return render_template(
+            "network.html",
+            config=cfg,
+        )
+
+    @app.route("/system")
+    @pam_required
+    def system_settings():
+        branches = system_manager.list_branches()
+        current_branch = system_manager.current_branch()
+        service_status = system_manager.service_status()
+        return render_template(
+            "system.html",
             config=cfg,
             branches=branches,
             current_branch=current_branch,
+            has_branch_info=bool(branches or current_branch),
+            fallback_repo=system_manager.fallback_repo,
             service_status=service_status,
-            auto_totals=auto_totals,
         )
-
-    @app.route("/playlist", methods=["POST"])
-    @pam_required
-    def playlist_add():
-        source = request.form.get("source")
-        path = request.form.get("path")
-        duration = request.form.get("duration")
-        item_type = media_manager.detect_item_type(path or "")
-        if not source or not path:
-            flash("Quelle und Pfad müssen angegeben werden", "danger")
-            return redirect(url_for("dashboard"))
-        media_manager.add_to_playlist(PlaylistItem(source=source, path=path, type=item_type, duration=int(duration) if duration else None))
-        player.reload()
-        flash("Element hinzugefügt", "success")
-        return redirect(url_for("dashboard"))
 
     @app.route("/logs/<string:name>")
     @pam_required
@@ -165,17 +191,68 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     @app.route("/sources/smb", methods=["POST"])
     @pam_required
     def add_smb_source():
-        name = request.form.get("name")
-        server = request.form.get("server")
-        share = request.form.get("share")
-        username = request.form.get("username") or None
-        password = request.form.get("password") or None
-        if not all([name, server, share]):
-            flash("Name, Server und Freigabe sind erforderlich", "danger")
-            return redirect(url_for("dashboard"))
-        media_manager.add_smb_source(name=name, server=server, share=share, username=username, password=password)
+        name = (request.form.get("name") or "").strip()
+        smb_path = (request.form.get("smb_path") or "").strip()
+        server = (request.form.get("server") or "").strip() or None
+        share = (request.form.get("share") or "").strip() or None
+        subpath = (request.form.get("subpath") or "").strip() or None
+        domain = (request.form.get("domain") or "").strip() or None
+        username = (request.form.get("username") or "").strip() or None
+        password = (request.form.get("password") or "").strip() or None
+        auto_scan = request.form.get("auto_scan") in {"1", "true", "on"}
+
+        if not name:
+            flash("Name der Quelle ist erforderlich", "danger")
+            return redirect(url_for("media_settings"))
+
+        try:
+            media_manager.add_smb_source(
+                name=name,
+                server=server,
+                share=share,
+                username=username,
+                password=password,
+                domain=domain,
+                subpath=subpath,
+                smb_path=smb_path,
+                auto_scan=auto_scan,
+            )
+        except ValueError as exc:
+            flash(str(exc), "danger")
+            return redirect(url_for("media_settings"))
+
         flash("SMB-Quelle hinzugefügt", "success")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("media_settings"))
+
+    @app.route("/sources/<path:name>/auto-scan", methods=["POST"])
+    @pam_required
+    def toggle_auto_scan(name: str):
+        enabled = request.form.get("enabled") in {"1", "true", "on"}
+        try:
+            media_manager.set_auto_scan(name, enabled)
+            player.reload()
+        except ValueError as exc:
+            flash(str(exc), "danger")
+        else:
+            status = "aktiviert" if enabled else "deaktiviert"
+            flash(f"Automatischer Scan für {name} {status}", "success")
+        return redirect(url_for("media_settings"))
+
+    @app.route("/sources/<path:name>/delete", methods=["POST"])
+    @pam_required
+    def delete_source(name: str):
+        confirm = request.form.get("confirm")
+        if confirm not in {"1", "true", "on", "yes"}:
+            flash("Löschung nicht bestätigt", "warning")
+            return redirect(url_for("media_settings"))
+        try:
+            media_manager.remove_source(name)
+            player.reload()
+        except ValueError as exc:
+            flash(str(exc), "danger")
+        else:
+            flash(f"Quelle {name} entfernt", "info")
+        return redirect(url_for("media_settings"))
 
     @app.route("/network", methods=["POST"])
     @pam_required
@@ -193,7 +270,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         else:
             network_manager.configure_dhcp(interface)
         flash("Netzwerk aktualisiert", "success")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("network_settings"))
 
     @app.route("/player/<string:action>", methods=["POST"])
     @pam_required
@@ -213,7 +290,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         except Exception as exc:  # pragma: no cover - defensive
             LOGGER.exception("Fehler bei Player-Aktion")
             flash(f"Aktion fehlgeschlagen: {exc}", "danger")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("playback_settings_page"))
 
     @app.route("/player/info-screen", methods=["POST"])
     @pam_required
@@ -221,12 +298,24 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         enabled = request.form.get("enabled") == "1"
         player.show_info_screen(enabled)
         flash("Infobildschirm aktiviert" if enabled else "Infobildschirm deaktiviert", "info")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("playback_settings_page"))
 
     @app.route("/playback/settings", methods=["POST"])
     @pam_required
     def update_playback_settings():
         playback = cfg.playback
+
+        def parse_args(field: str, current: List[str]) -> List[str]:
+            raw = request.form.get(field)
+            if raw is None:
+                return current
+            items: List[str] = []
+            for entry in raw.replace("\r", "").splitlines():
+                entry = entry.strip()
+                if entry:
+                    items.append(entry)
+            return items
+
         try:
             playback.image_duration = max(1, int(request.form.get("image_duration") or playback.image_duration))
         except ValueError:
@@ -258,6 +347,19 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         display_resolution = (request.form.get("display_resolution") or playback.display_resolution).strip()
         playback.display_resolution = display_resolution
 
+        video_backend = (request.form.get("video_backend") or playback.video_backend or "auto").lower()
+        if video_backend not in {"auto", "x11", "drm"}:
+            video_backend = "auto"
+        playback.video_backend = video_backend
+
+        image_backend = (request.form.get("image_backend") or playback.image_backend or video_backend).lower()
+        if image_backend not in {"auto", "x11", "drm"}:
+            image_backend = video_backend
+        playback.image_backend = image_backend
+
+        playback.video_player_args = parse_args("video_player_args", playback.video_player_args)
+        playback.image_viewer_args = parse_args("image_viewer_args", playback.image_viewer_args)
+
         splitscreen_enabled = request.form.get("splitscreen_enabled") in {"1", "true", "on"}
         playback.splitscreen_enabled = splitscreen_enabled
         left_source = request.form.get("splitscreen_left_source")
@@ -270,7 +372,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         cfg.save()
         player.reload()
         flash("Wiedergabe-Einstellungen gespeichert", "success")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("playback_settings_page"))
 
     @app.route("/system/update", methods=["POST"])
     @pam_required
@@ -284,7 +386,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             flash(f"Update fehlgeschlagen: {exc}", "danger")
         except ValueError as exc:
             flash(str(exc), "danger")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("system_settings"))
 
     @app.route("/system/service/<string:action>", methods=["POST"])
     @pam_required
@@ -295,7 +397,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         except (subprocess.CalledProcessError, ValueError, RuntimeError) as exc:
             LOGGER.exception("Serviceaktion fehlgeschlagen")
             flash(f"Serviceaktion fehlgeschlagen: {exc}", "danger")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("system_settings"))
 
     @app.route("/system/reboot", methods=["POST"])
     @pam_required
@@ -306,7 +408,18 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         except (subprocess.CalledProcessError, RuntimeError) as exc:
             LOGGER.exception("Neustart fehlgeschlagen")
             flash(f"Neustart fehlgeschlagen: {exc}", "danger")
-        return redirect(url_for("dashboard"))
+        return redirect(url_for("system_settings"))
+
+    @app.route("/system/shutdown", methods=["POST"])
+    @pam_required
+    def system_shutdown():
+        try:
+            system_manager.shutdown()
+            flash("Shutdown ausgelöst", "warning")
+        except (subprocess.CalledProcessError, RuntimeError) as exc:
+            LOGGER.exception("Shutdown fehlgeschlagen")
+            flash(f"Shutdown fehlgeschlagen: {exc}", "danger")
+        return redirect(url_for("system_settings"))
 
     # API ---------------------------------------------------------------
     @app.route("/api/state")

--- a/slideshow/info.py
+++ b/slideshow/info.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 import datetime as _dt
 import pathlib
-from typing import Iterable
+from typing import Iterable, Optional, Sequence
 
 from PIL import Image, ImageDraw, ImageFont
 
-BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
-DATA_DIR = BASE_DIR / "data"
+from .config import DATA_DIR
+
 INFO_DIR = DATA_DIR / "info"
 
 
@@ -19,7 +19,13 @@ class InfoScreen:
         self.output_dir = pathlib.Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-    def render(self, hostname: str, addresses: Iterable[str], manual: bool = False) -> pathlib.Path:
+    def render(
+        self,
+        hostname: str,
+        addresses: Iterable[str],
+        manual: bool = False,
+        details: Optional[Sequence[str]] = None,
+    ) -> pathlib.Path:
         width, height = 1280, 720
         image = Image.new("RGB", (width, height), color="#0b1d36")
         draw = ImageDraw.Draw(image)
@@ -43,6 +49,9 @@ class InfoScreen:
         lines.append(f"Stand: {now}")
         if manual:
             lines.append("(Infobildschirm manuell aktiviert)")
+        if details:
+            lines.append("")
+            lines.extend(details)
 
         draw.text((60, 60), lines[0], font=font_title, fill="#f7faff")
         offset_y = 160

--- a/slideshow/media.py
+++ b/slideshow/media.py
@@ -5,13 +5,22 @@ import logging
 import mimetypes
 import os
 import pathlib
+import re
 import shlex
 import shutil
 import subprocess
 from dataclasses import asdict
-from typing import Iterable, List, Optional
+from typing import List, Optional
 
-from .config import AppConfig, MediaSource, PlaylistItem, load_secret, save_secret
+from .config import (
+    AppConfig,
+    DATA_DIR,
+    MediaSource,
+    PlaylistItem,
+    delete_secret,
+    load_secret,
+    save_secret,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +29,52 @@ VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_MOUNT_HELPER = BASE_DIR / "scripts" / "mount_smb.sh"
+MOUNT_ROOT = (DATA_DIR / "mounts").resolve()
+
+
+def _paths_equal(left: pathlib.Path, right: pathlib.Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except FileNotFoundError:
+        return left.absolute() == right.absolute()
+
+
+def _unescape_mount_path(value: str) -> str:
+    return (
+        value.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+    )
+
+
+def _normalize_subpath(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    sanitized = str(value).replace("\\", "/").strip("/")
+    return sanitized or None
+
+
+def parse_smb_location(raw_path: str) -> tuple[str, str, Optional[str]]:
+    """Zerlegt eine SMB-Pfadangabe in Server, Freigabe und Unterordner."""
+
+    if not raw_path:
+        raise ValueError("SMB-Pfad darf nicht leer sein")
+
+    cleaned = raw_path.strip()
+    if cleaned.lower().startswith("smb://"):
+        cleaned = cleaned[6:]
+    cleaned = cleaned.lstrip("\\/")
+    cleaned = cleaned.replace("\\", "/")
+    parts = [part for part in cleaned.split("/") if part]
+
+    if len(parts) < 2:
+        raise ValueError("SMB-Pfad muss Server und Freigabe enthalten")
+
+    server = parts[0]
+    share = parts[1]
+    subpath = "/".join(parts[2:]) if len(parts) > 2 else None
+    return server, share, _normalize_subpath(subpath)
 
 
 class MediaManager:
@@ -27,8 +82,96 @@ class MediaManager:
         self.config = config
         helper_path = os.environ.get("SLIDESHOW_MOUNT_HELPER")
         self.mount_helper = pathlib.Path(helper_path) if helper_path else DEFAULT_MOUNT_HELPER
+        try:
+            MOUNT_ROOT.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            LOGGER.warning("Konnte Mount-Verzeichnis %s nicht anlegen: %s", MOUNT_ROOT, exc)
+        self._migrate_mount_points()
+        self._ensure_local_directories()
 
-    def _run_mount_helper(self, *args: str) -> subprocess.CompletedProcess:
+    # Initialisierungs-Helfer --------------------------------------------
+    def _is_mount_active(self, mount_point: pathlib.Path) -> bool:
+        path = pathlib.Path(mount_point)
+        try:
+            resolved = path.resolve()
+        except FileNotFoundError:
+            return False
+        if os.path.ismount(str(resolved)):
+            return True
+        try:
+            with open("/proc/self/mounts", "r", encoding="utf-8") as handle:
+                for line in handle:
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        mount_target = pathlib.Path(_unescape_mount_path(parts[1]))
+                        if _paths_equal(mount_target, resolved):
+                            return True
+        except OSError:
+            pass
+        return False
+
+    def _ensure_local_directories(self) -> None:
+        for source in self.config.media_sources:
+            if source.type == "local":
+                try:
+                    pathlib.Path(source.path).mkdir(parents=True, exist_ok=True)
+                except OSError as exc:
+                    LOGGER.warning("Konnte lokales Verzeichnis %s nicht erstellen: %s", source.path, exc)
+
+    def _slugify(self, name: str) -> str:
+        slug = re.sub(r"[^A-Za-z0-9_-]+", "-", name.strip()).strip("-")
+        return slug or "smb-source"
+
+    def _allocate_mount_point(self, name: str) -> pathlib.Path:
+        base_slug = self._slugify(name)
+        candidate = MOUNT_ROOT / base_slug
+        counter = 2
+        existing_paths = {
+            pathlib.Path(src.path).expanduser().resolve()
+            for src in self.config.media_sources
+            if src.type == "smb"
+        }
+        resolved = candidate.expanduser().resolve()
+        while resolved in existing_paths or candidate.exists():
+            candidate = MOUNT_ROOT / f"{base_slug}-{counter}"
+            counter += 1
+            resolved = candidate.expanduser().resolve()
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            # mkdir kann scheitern, der Mount-Helfer legt später erneut an.
+            pass
+        return resolved
+
+    def _is_writable(self, path: pathlib.Path) -> bool:
+        try:
+            if not path.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.mkdir(exist_ok=True)
+            return os.access(str(path), os.W_OK)
+        except OSError:
+            return False
+
+    def _migrate_mount_points(self) -> None:
+        changed = False
+        for source in self.config.media_sources:
+            if source.type != "smb":
+                continue
+            original_path = pathlib.Path(source.path)
+            if not original_path.is_absolute():
+                continue
+            if str(original_path).startswith("/mnt/slideshow"):
+                if not original_path.exists() or not os.access(str(original_path.parent), os.W_OK):
+                    new_path = self._allocate_mount_point(source.name)
+                    LOGGER.info(
+                        "Verschiebe Mountpunkt für %s von %s nach %s", source.name, original_path, new_path
+                    )
+                    source.path = str(new_path)
+                    changed = True
+        if changed:
+            self.config.save()
+
+    def _run_mount_helper(self, *args: str, ignore_busy: bool = False) -> subprocess.CompletedProcess:
         helper = self.mount_helper
         if not helper.exists():
             raise FileNotFoundError(f"Mount-Helfer {helper} nicht gefunden")
@@ -44,6 +187,13 @@ class MediaManager:
             stderr = (result.stderr or "").strip()
             stdout = (result.stdout or "").strip()
             message = stderr or stdout or "unbekannter Fehler"
+            if ignore_busy and result.returncode == 16:
+                LOGGER.debug(
+                    "Mount-Helfer meldete 'busy' (%s), behandle als Erfolg: %s",
+                    result.returncode,
+                    message,
+                )
+                return result
             raise RuntimeError(f"Mount-Helfer fehlgeschlagen ({result.returncode}): {message}")
         return result
 
@@ -54,24 +204,47 @@ class MediaManager:
     def add_smb_source(
         self,
         name: str,
-        server: str,
-        share: str,
+        server: Optional[str] = None,
+        share: Optional[str] = None,
+        *,
         mount_point: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
+        domain: Optional[str] = None,
+        subpath: Optional[str] = None,
+        smb_path: Optional[str] = None,
         auto_scan: bool = True,
     ) -> MediaSource:
-        mount_point = mount_point or f"/mnt/slideshow/{name}"
+        if smb_path:
+            parsed_server, parsed_share, parsed_subpath = parse_smb_location(smb_path)
+            server = server or parsed_server
+            share = share or parsed_share
+            subpath = subpath or parsed_subpath
+
+        if not server or not share:
+            raise ValueError("Server und Freigabe müssen angegeben werden")
+
+        if mount_point:
+            mount_path = pathlib.Path(mount_point).expanduser().resolve()
+        else:
+            mount_path = self._allocate_mount_point(name)
+        if not self._is_writable(mount_path):
+            raise PermissionError(f"Mount-Ziel {mount_path} ist nicht beschreibbar")
+        normalized_subpath = _normalize_subpath(subpath)
+        options = {
+            "server": server,
+            "share": share,
+            "username": username,
+        }
+        if domain:
+            options["domain"] = domain
         source = MediaSource(
             name=name,
             type="smb",
-            path=mount_point,
-            options={
-                "server": server,
-                "share": share,
-                "username": username,
-            },
+            path=str(mount_path),
+            options=options,
             auto_scan=auto_scan,
+            subpath=normalized_subpath,
         )
         if password:
             save_secret(f"smb:{name}", password)
@@ -79,12 +252,45 @@ class MediaManager:
         self.config.save()
         return source
 
+    def set_auto_scan(self, name: str, enabled: bool) -> MediaSource:
+        source = self.config.get_source(name)
+        if not source:
+            raise ValueError(f"Unbekannte Quelle: {name}")
+        if source.auto_scan != enabled:
+            source.auto_scan = enabled
+            self.config.save()
+        return source
+
+    def remove_source(self, name: str) -> None:
+        source = self.config.get_source(name)
+        if not source:
+            raise ValueError(f"Unbekannte Quelle: {name}")
+        if source.type == "local":
+            raise ValueError("Die lokale Standardquelle kann nicht entfernt werden")
+        try:
+            self.unmount_source(source)
+        except Exception:
+            LOGGER.debug("Unmount vor dem Löschen von %s fehlgeschlagen", name)
+        mount_path = pathlib.Path(source.path)
+        try:
+            if mount_path.exists() and mount_path.is_dir():
+                if mount_path.resolve().is_relative_to(MOUNT_ROOT):
+                    shutil.rmtree(mount_path, ignore_errors=True)
+        except Exception as exc:
+            LOGGER.debug("Konnte Mount-Verzeichnis %s nicht entfernen: %s", mount_path, exc)
+        self.config.media_sources = [src for src in self.config.media_sources if src.name != name]
+        delete_secret(f"smb:{name}")
+        self.config.save()
+
     def mount_source(self, source: MediaSource) -> None:
         if source.type != "smb":
             return
         password = load_secret(f"smb:{source.name}")
         mount_point = pathlib.Path(source.path)
         mount_point.mkdir(parents=True, exist_ok=True)
+        if self._is_mount_active(mount_point):
+            LOGGER.debug("Mountpunkt %s ist bereits aktiv", mount_point)
+            return
         uid = os.getuid()
         gid = os.getgid()
         vers = source.options.get("vers", "3.1.1")
@@ -104,6 +310,9 @@ class MediaManager:
             option_parts.insert(0, f"password={password}")
         else:
             option_parts.insert(0, "guest")
+        domain = source.options.get("domain")
+        if domain:
+            option_parts.insert(0, f"domain={domain}")
         extra_options = source.options.get("options") or source.options.get("extra_options")
         if isinstance(extra_options, str) and extra_options.strip():
             option_parts.append(extra_options.strip())
@@ -114,7 +323,7 @@ class MediaManager:
         share = f"//{source.options['server']}/{source.options['share']}"
         LOGGER.info("Mount SMB share %s auf %s", share, mount_point)
         try:
-            self._run_mount_helper("mount", share, str(mount_point), options)
+            self._run_mount_helper("mount", share, str(mount_point), options, ignore_busy=True)
         except Exception as exc:
             LOGGER.warning("Mount von %s fehlgeschlagen: %s", share, exc)
             raise
@@ -157,7 +366,11 @@ class MediaManager:
     def scan_directory(self, source: MediaSource, base_path: Optional[str] = None) -> List[PlaylistItem]:
         items: List[PlaylistItem] = []
         source_root = pathlib.Path(source.path)
-        base = source_root / base_path if base_path else source_root
+        subpath = base_path
+        if not subpath:
+            subpath = source.subpath
+        normalized = _normalize_subpath(subpath)
+        base = source_root / pathlib.Path(normalized) if normalized else source_root
         if not base.exists():
             LOGGER.warning("Verzeichnis %s existiert nicht", base)
             return []
@@ -234,7 +447,17 @@ class MediaManager:
                 except Exception as exc:  # pragma: no cover - defensive
                     LOGGER.warning("Konnte linke Quelle %s nicht mounten: %s", left_source, exc)
                 else:
-                    left_items = self.scan_directory(source, left_path or None)
+                    base = left_path or None
+                    if base and source.subpath:
+                        base = "/".join(
+                            part
+                            for part in (
+                                _normalize_subpath(source.subpath),
+                                _normalize_subpath(base),
+                            )
+                            if part
+                        )
+                    left_items = self.scan_directory(source, base)
             else:
                 LOGGER.warning("Linke Quelle %s unbekannt", left_source)
 
@@ -246,7 +469,17 @@ class MediaManager:
                 except Exception as exc:  # pragma: no cover - defensive
                     LOGGER.warning("Konnte rechte Quelle %s nicht mounten: %s", right_source, exc)
                 else:
-                    right_items = self.scan_directory(source, right_path or None)
+                    base = right_path or None
+                    if base and source.subpath:
+                        base = "/".join(
+                            part
+                            for part in (
+                                _normalize_subpath(source.subpath),
+                                _normalize_subpath(base),
+                            )
+                            if part
+                        )
+                    right_items = self.scan_directory(source, base)
             else:
                 LOGGER.warning("Rechte Quelle %s unbekannt", right_source)
 

--- a/slideshow/player.py
+++ b/slideshow/player.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import os
 from typing import Dict, List, Optional, Tuple
 
 from PIL import Image
@@ -329,18 +330,16 @@ class PlayerService:
             secondary_status="stopped" if clear_secondary else None,
         )
         if player == "mpv":
+            backend = self._resolve_backend(self.config.playback.video_backend, "SLIDESHOW_VIDEO_BACKEND")
             cmd = [
                 player,
                 "--no-terminal",
                 "--quiet",
                 "--loop-file=no",
-                "--force-window=yes",
                 "--keep-open=no",
             ]
-            if geometry:
-                cmd.append(f"--geometry={geometry}")
-            else:
-                cmd.append("--fullscreen")
+            cmd.extend(self._mpv_backend_args(backend, geometry, media_type="video"))
+            cmd.extend(self.config.playback.video_player_args)
             cmd.append(str(path))
             subprocess.run(cmd, check=False)
         elif player == "omxplayer":
@@ -388,20 +387,18 @@ class PlayerService:
 
         viewer = self.config.playback.image_viewer
         if viewer == "mpv":
+            backend = self._resolve_backend(self.config.playback.image_backend, "SLIDESHOW_IMAGE_BACKEND")
             cmd = [
                 viewer,
                 "--no-terminal",
                 "--quiet",
                 "--loop-file=no",
-                "--force-window=yes",
                 "--keep-open=no",
                 f"--image-display-duration={duration}",
                 "--terminate-on-last-frame=yes",
             ]
-            if geometry:
-                cmd.append(f"--geometry={geometry}")
-            else:
-                cmd.append("--fullscreen")
+            cmd.extend(self._mpv_backend_args(backend, geometry, media_type="image"))
+            cmd.extend(self.config.playback.image_viewer_args)
             cmd.append(str(processed_path))
             subprocess.run(cmd, check=False)
         elif viewer == "feh":
@@ -585,10 +582,76 @@ class PlayerService:
             except Exception:
                 LOGGER.debug("Konnte temporäres Verzeichnis nicht entfernen")
 
+    def _resolve_backend(self, configured: Optional[str], env_var: str) -> str:
+        value = (configured or "auto").strip().lower()
+        if value == "auto":
+            env_value = os.environ.get(env_var)
+            if env_value:
+                value = env_value.strip().lower()
+        if value == "auto":
+            value = "x11" if os.environ.get("DISPLAY") else "drm"
+        if value not in {"x11", "drm"}:
+            LOGGER.debug("Unbekanntes Backend %s, Standard 'x11' wird verwendet", value)
+            return "x11"
+        return value
+
+    def _mpv_backend_args(
+        self,
+        backend: str,
+        geometry: Optional[str],
+        *,
+        media_type: str,
+    ) -> List[str]:
+        args: List[str] = []
+        if backend == "x11":
+            args.append("--force-window=yes")
+            if geometry:
+                args.append(f"--geometry={geometry}")
+            else:
+                args.append("--fullscreen")
+        elif backend == "drm":
+            args.extend(["--vo=gpu", "--gpu-context=drm", "--hwdec=auto"])
+            if not geometry:
+                args.append("--fullscreen")
+            elif media_type == "video":
+                LOGGER.debug("DRM-Modus ignoriert Geometrie %s", geometry)
+        else:
+            if geometry:
+                args.append(f"--geometry={geometry}")
+            else:
+                args.append("--fullscreen")
+        return args
+
     def _display_info_screen(self, manual: bool) -> None:
         hostname = resolve_hostname()
         addresses = resolve_ip_addresses()
-        info_path = self._info_screen.render(hostname=hostname, addresses=addresses, manual=manual)
+        network = self.config.network
+        playback = self.config.playback
+        details = []
+        if network.interface:
+            details.append(f"Netzwerkinterface: {network.interface}")
+        mode = (network.mode or "dhcp").lower()
+        if mode == "static":
+            address = (network.static or {}).get("address") if network.static else None
+            router = (network.static or {}).get("router") if network.static else None
+            details.append(
+                "Netzwerkmodus: Statisch" + (f" ({address})" if address else "")
+            )
+            if router:
+                details.append(f"Gateway: {router}")
+        else:
+            details.append("Netzwerkmodus: DHCP")
+        details.append(f"Medienverzeichnis: {self.config.media_root}")
+        details.append(
+            f"Automatischer Start: {'Ja' if playback.auto_start else 'Nein'}"
+        )
+        details.append(f"Displayauflösung: {playback.display_resolution}")
+        info_path = self._info_screen.render(
+            hostname=hostname,
+            addresses=addresses,
+            manual=manual,
+            details=details,
+        )
         set_state(
             str(info_path),
             "info",

--- a/slideshow/state.py
+++ b/slideshow/state.py
@@ -5,11 +5,9 @@ import json
 import threading
 import time
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import Optional
 
-BASE_DIR = Path(__file__).resolve().parent.parent
-DATA_DIR = BASE_DIR / "data"
+from .config import DATA_DIR
 STATE_PATH = DATA_DIR / "state.json"
 
 _lock = threading.Lock()
@@ -62,7 +60,7 @@ def load_state() -> PlaybackState:
 
 
 def save_state(state: PlaybackState) -> None:
-    DATA_DIR.mkdir(exist_ok=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(asdict(state)), encoding="utf-8")
 
 

--- a/slideshow/static/style.css
+++ b/slideshow/static/style.css
@@ -27,16 +27,23 @@ body {
   flex-wrap: wrap;
 }
 
-.topbar nav {
+.topbar .main-nav {
   display: flex;
   gap: 1rem;
 }
 
-.topbar nav a {
+.topbar .main-nav a {
   color: var(--fg);
-  margin-left: 1rem;
   text-decoration: none;
   font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.topbar .main-nav a.active,
+.topbar .main-nav a:hover {
+  background: rgba(59, 130, 246, 0.25);
 }
 
 .topbar .version {
@@ -53,6 +60,14 @@ body {
   display: grid;
   gap: 1.5rem;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.overview-grid {
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.system-grid {
+  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
 }
 
 article {
@@ -84,6 +99,10 @@ table {
   margin-bottom: 1rem;
 }
 
+.table-wrapper {
+  overflow-x: auto;
+}
+
 table th,
 table td {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -107,10 +126,16 @@ button {
   border: none;
   cursor: pointer;
   color: white;
+  transition: filter 0.2s ease;
 }
 
 button.danger {
   background: #e53e3e;
+}
+
+button:hover,
+.button-link:hover {
+  filter: brightness(1.1);
 }
 
 form {
@@ -151,6 +176,17 @@ form {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.85rem;
   white-space: pre-wrap;
+}
+
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.table-actions form {
+  margin: 0;
 }
 
 .inline-form label {
@@ -203,6 +239,32 @@ form {
 
 .checkbox input[type="checkbox"] {
   width: auto;
+}
+
+.muted {
+  color: rgba(248, 250, 252, 0.75);
+  font-size: 0.95rem;
+}
+
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(59, 130, 246, 0.35);
+  color: var(--fg);
+  text-decoration: none;
+  font-weight: 600;
+  margin-top: 0.5rem;
+}
+
+.hint-list {
+  padding-left: 1.2rem;
+}
+
+.hint-list li {
+  margin-bottom: 0.5rem;
 }
 
 .flash-container {

--- a/slideshow/templates/dashboard.html
+++ b/slideshow/templates/dashboard.html
@@ -1,313 +1,58 @@
 {% extends 'layout.html' %}
-{% block title %}Dashboard – Slideshow{% endblock %}
+{% block title %}Übersicht – Slideshow{% endblock %}
 {% block content %}
-<section class="grid">
+<section class="grid overview-grid">
   <article>
     <h2>Aktueller Status</h2>
     <div class="status-block">
-      <h3>Hauptanzeige</h3>
+      <h3>Primäre Anzeige</h3>
       <p><strong>Datei:</strong> {{ state.primary_item or '–' }}</p>
-      <p><strong>Status:</strong> {{ state.primary_status }}</p>
+      <p><strong>Status:</strong> {{ state.primary_status or 'unbekannt' }}</p>
       <p><strong>Gestartet:</strong> {% if state.primary_started_at %}{{ state.primary_started_at | datetimeformat }}{% else %}–{% endif %}</p>
     </div>
-    {% if state.secondary_item or config.playback.splitscreen_enabled %}
+    {% if config.playback.splitscreen_enabled %}
     <div class="status-block">
       <h3>Splitscreen rechts</h3>
       <p><strong>Datei:</strong> {{ state.secondary_item or '–' }}</p>
-      <p><strong>Status:</strong> {{ state.secondary_status }}</p>
+      <p><strong>Status:</strong> {{ state.secondary_status or 'unbekannt' }}</p>
       <p><strong>Gestartet:</strong> {% if state.secondary_started_at %}{{ state.secondary_started_at | datetimeformat }}{% else %}–{% endif %}</p>
     </div>
     {% endif %}
     <p><strong>Infobildschirm:</strong> {% if state.info_screen %}aktiv{% else %}inaktiv{% endif %}{% if state.info_manual %} (manuell){% endif %}</p>
-    <p><strong>Service-Status:</strong> {{ service_status }}</p>
-    <p><strong>Git-Branch:</strong> {{ current_branch or 'unbekannt' }}</p>
+    <p><strong>Service-Status:</strong> {{ service_status or 'unbekannt' }}</p>
+    <p><strong>Autostart:</strong> {% if config.playback.auto_start %}aktiviert{% else %}deaktiviert{% endif %}</p>
   </article>
 
   <article>
-    <h2>Playlist</h2>
-    <table>
-      <thead>
-        <tr><th>#</th><th>Datei</th><th>Quelle</th><th>Typ</th><th>Aktionen</th></tr>
-      </thead>
-      <tbody>
-        {% for item in playlist %}
-        <tr>
-          <td>{{ loop.index }}</td>
-          <td>{{ item.path }}</td>
-          <td>{{ item.source }}</td>
-          <td>{{ item.type }}</td>
-          <td>
-            <form method="post" action="{{ url_for('playlist_delete', index=loop.index0) }}">
-              <button type="submit">Entfernen</button>
-            </form>
-          </td>
-        </tr>
-        {% else %}
-        <tr><td colspan="5">Keine Einträge</td></tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-    <form class="inline-form" method="post" action="{{ url_for('playlist_add') }}">
-      <h3>Manuell hinzufügen</h3>
-      <label>Quelle
-        <select name="source">
-          {% for source in sources %}
-            <option value="{{ source.name }}">{{ source.name }} ({{ source.type }})</option>
+    <h2>Playlist-Vorschau</h2>
+    <p class="muted">Die Wiedergabe wird automatisch aus allen aktiv überwachten Quellen aufgebaut. Neu hinzugefügte Dateien werden nach kurzer Zeit ohne manuelle Eingriffe angezeigt.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Datei</th>
+            <th>Quelle</th>
+            <th>Typ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for item in playlist %}
+          <tr>
+            <td>{{ loop.index }}</td>
+            <td>{{ item.path }}</td>
+            <td>{{ item.source }}</td>
+            <td>{{ item.type }}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="4">Keine Medien gefunden. Bitte prüfen, ob die Quellen erreichbar sind.</td>
+          </tr>
           {% endfor %}
-        </select>
-      </label>
-      <label>Pfad (relativ zur Quelle)
-        <input type="text" name="path" required />
-      </label>
-      <label>Dauer (Sek.)
-        <input type="number" name="duration" min="1" />
-      </label>
-      <button type="submit">Hinzufügen</button>
-    </form>
-    {% if auto_totals %}
-    <h3>Automatische Medien</h3>
-    <ul>
-      {% for name, total in auto_totals.items() %}
-      <li>{{ name }}: {{ total }} Datei{% if total != 1 %}en{% endif %}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-  </article>
-
-  <article>
-    <h2>SMB-Quelle hinzufügen</h2>
-    <form method="post" action="{{ url_for('add_smb_source') }}">
-      <label>Name<input type="text" name="name" required /></label>
-      <label>Server/IP<input type="text" name="server" required /></label>
-      <label>Freigabe<input type="text" name="share" required /></label>
-      <label>Benutzer<input type="text" name="username" /></label>
-      <label>Passwort<input type="password" name="password" /></label>
-      <button type="submit">Quelle speichern</button>
-    </form>
-  </article>
-
-  <article>
-    <h2>Steuerung</h2>
-    <form method="post" action="{{ url_for('player_control', action='start') }}">
-      <button type="submit">Slideshow starten</button>
-    </form>
-    <form method="post" action="{{ url_for('player_control', action='stop') }}">
-      <button type="submit">Slideshow stoppen</button>
-    </form>
-    <form method="post" action="{{ url_for('player_control', action='reload') }}">
-      <button type="submit">Playlist neu laden</button>
-    </form>
-    <form method="post" action="{{ url_for('player_info_screen') }}">
-      {% if state.info_screen %}
-      <input type="hidden" name="enabled" value="0" />
-      <button type="submit">Infobildschirm deaktivieren</button>
-      {% else %}
-      <input type="hidden" name="enabled" value="1" />
-      <button type="submit">Infobildschirm aktivieren</button>
-      {% endif %}
-    </form>
-  </article>
-
-  <article>
-    <h2>Anzeigeeinstellungen</h2>
-    <form method="post" action="{{ url_for('update_playback_settings') }}" class="grid-form">
-      <label>Bilddauer (Sekunden)
-        <input type="number" name="image_duration" min="1" value="{{ config.playback.image_duration }}" required />
-      </label>
-      <label>Bildmodus
-        <select name="image_fit">
-          <option value="contain" {% if config.playback.image_fit == 'contain' %}selected{% endif %}>Einpassen (mit Rändern)</option>
-          <option value="stretch" {% if config.playback.image_fit == 'stretch' %}selected{% endif %}>Strecken</option>
-          <option value="original" {% if config.playback.image_fit == 'original' %}selected{% endif %}>Originalgröße</option>
-        </select>
-      </label>
-      <label>Rotation (°)
-        <input type="number" name="image_rotation" min="0" max="359" value="{{ config.playback.image_rotation }}" />
-      </label>
-      <label>Übergang
-        <select name="transition_type">
-          <option value="none" {% if config.playback.transition_type == 'none' %}selected{% endif %}>Keiner</option>
-          <option value="fade" {% if config.playback.transition_type == 'fade' %}selected{% endif %}>Fade</option>
-          <option value="slide" {% if config.playback.transition_type == 'slide' %}selected{% endif %}>Slide</option>
-        </select>
-      </label>
-      <label>Übergangsdauer (Sekunden)
-        <input type="number" step="0.1" min="0.2" max="10" name="transition_duration" value="{{ config.playback.transition_duration }}" />
-      </label>
-      <label>Auflösung (Breite x Höhe)
-        <input type="text" name="display_resolution" value="{{ config.playback.display_resolution }}" />
-      </label>
-      <fieldset class="splitscreen">
-        <legend>Splitscreen</legend>
-        <label class="checkbox">
-          <input type="checkbox" name="splitscreen_enabled" value="1" {% if config.playback.splitscreen_enabled %}checked{% endif %} /> Aktivieren
-        </label>
-        <div class="split-grid">
-          <div>
-            <h4>Linke Seite</h4>
-            <label>Quelle
-              <select name="splitscreen_left_source">
-                <option value="">(keine)</option>
-                {% for source in sources %}
-                <option value="{{ source.name }}" {% if config.playback.splitscreen_left_source == source.name %}selected{% endif %}>{{ source.name }}</option>
-                {% endfor %}
-              </select>
-            </label>
-            <label>Pfad (optional)
-              <input type="text" name="splitscreen_left_path" value="{{ config.playback.splitscreen_left_path }}" />
-            </label>
-          </div>
-          <div>
-            <h4>Rechte Seite</h4>
-            <label>Quelle
-              <select name="splitscreen_right_source">
-                <option value="">(keine)</option>
-                {% for source in sources %}
-                <option value="{{ source.name }}" {% if config.playback.splitscreen_right_source == source.name %}selected{% endif %}>{{ source.name }}</option>
-                {% endfor %}
-              </select>
-            </label>
-            <label>Pfad (optional)
-              <input type="text" name="splitscreen_right_path" value="{{ config.playback.splitscreen_right_path }}" />
-            </label>
-          </div>
-        </div>
-      </fieldset>
-      <button type="submit">Einstellungen speichern</button>
-    </form>
-  </article>
-
-  <article>
-    <h2>Netzwerk</h2>
-    <form method="post" action="{{ url_for('update_network') }}">
-      <label>Hostname
-        <input type="text" name="hostname" value="{{ config.network.hostname or '' }}" />
-      </label>
-      <label>Interface
-        <input type="text" name="interface" value="{{ config.network.interface }}" />
-      </label>
-      <label>Modus
-        <select name="mode">
-          <option value="dhcp" {% if config.network.mode == 'dhcp' %}selected{% endif %}>DHCP</option>
-          <option value="static" {% if config.network.mode == 'static' %}selected{% endif %}>Statisch</option>
-        </select>
-      </label>
-      <div class="static-config">
-        <label>Adresse
-          <input type="text" name="address" value="{{ config.network.static.address }}" />
-        </label>
-        <label>Gateway
-          <input type="text" name="router" value="{{ config.network.static.router }}" />
-        </label>
-        <label>DNS (kommagetrennt)
-          <input type="text" name="dns" value="{{ config.network.static.dns | join(',') }}" />
-        </label>
-      </div>
-      <button type="submit">Speichern</button>
-    </form>
-  </article>
-
-  <article>
-    <h2>Updates &amp; System</h2>
-    <form method="post" action="{{ url_for('system_update') }}">
-      <label>Branch auswählen
-        <select name="branch">
-          {% set displayed = false %}
-          {% for branch in branches %}
-            {% set displayed = true %}
-            <option value="{{ branch }}" {% if branch == current_branch %}selected{% endif %}>{{ branch }}</option>
-          {% endfor %}
-          {% if not displayed and current_branch %}
-            <option value="{{ current_branch }}" selected>{{ current_branch }}</option>
-          {% endif %}
-        </select>
-      </label>
-      <button type="submit">Update starten</button>
-    </form>
-    <div class="button-row">
-      <form method="post" action="{{ url_for('system_service', action='restart') }}">
-        <button type="submit">Service neu starten</button>
-      </form>
-      <form method="post" action="{{ url_for('system_service', action='start') }}">
-        <button type="submit">Service starten</button>
-      </form>
-      <form method="post" action="{{ url_for('system_service', action='stop') }}">
-        <button type="submit">Service stoppen</button>
-      </form>
+        </tbody>
+      </table>
     </div>
-    <form method="post" action="{{ url_for('system_reboot') }}" onsubmit="return confirm('Raspberry Pi wirklich neu starten?');">
-      <button type="submit" class="danger">Raspberry Pi neu starten</button>
-    </form>
-  </article>
-
-  <article class="logs">
-    <h2>Protokolle</h2>
-    <div class="log-controls">
-      <label>Log auswählen
-        <select id="log-select">
-          {% for key, info in log_sources.items() %}
-          <option value="{{ key }}">{{ info.label }}</option>
-          {% endfor %}
-        </select>
-      </label>
-      <label>Zeilen
-        <input type="number" id="log-lines" value="200" min="10" max="2000" />
-      </label>
-      <button type="button" id="log-refresh">Aktualisieren</button>
-    </div>
-    <pre id="log-output">Wähle ein Log aus, um den Inhalt zu laden.</pre>
+    <a class="button-link" href="{{ url_for('media_settings') }}">Quellen verwalten</a>
   </article>
 </section>
-{% endblock %}
-
-{% block scripts %}
-{{ super() }}
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const select = document.getElementById('log-select');
-    const output = document.getElementById('log-output');
-    const linesInput = document.getElementById('log-lines');
-    const refresh = document.getElementById('log-refresh');
-    const baseUrl = "{{ url_for('show_log', name='__LOG__') }}";
-
-    async function loadLog() {
-      if (!select || !output) {
-        return;
-      }
-      const name = select.value;
-      const lines = linesInput && linesInput.value ? linesInput.value : '200';
-      if (!name) {
-        output.textContent = 'Keine Logdatei ausgewählt.';
-        return;
-      }
-      output.textContent = 'Lade Log …';
-      try {
-        const response = await fetch(baseUrl.replace('__LOG__', encodeURIComponent(name)) + `?lines=${encodeURIComponent(lines)}`);
-        if (!response.ok) {
-          output.textContent = `Fehler beim Laden (${response.status})`;
-          return;
-        }
-        const text = await response.text();
-        output.textContent = text || 'Keine Einträge vorhanden.';
-      } catch (error) {
-        output.textContent = 'Fehler beim Abrufen des Logs.';
-      }
-    }
-
-    if (refresh) {
-      refresh.addEventListener('click', loadLog);
-    }
-    if (select) {
-      select.addEventListener('change', loadLog);
-    }
-    if (linesInput) {
-      linesInput.addEventListener('change', loadLog);
-    }
-
-    if (select && select.value) {
-      loadLog();
-    }
-  });
-</script>
 {% endblock %}

--- a/slideshow/templates/layout.html
+++ b/slideshow/templates/layout.html
@@ -10,8 +10,12 @@
     <header class="topbar">
       <h1>Slideshow Steuerung</h1>
       <div class="version">Version {{ slideshow_version }}</div>
-      <nav>
-        <a href="{{ url_for('dashboard') }}">Dashboard</a>
+      <nav class="main-nav">
+        <a href="{{ url_for('dashboard') }}" class="{% if request.endpoint == 'dashboard' %}active{% endif %}">Übersicht</a>
+        <a href="{{ url_for('media_settings') }}" class="{% if request.endpoint == 'media_settings' %}active{% endif %}">Medien</a>
+        <a href="{{ url_for('playback_settings_page') }}" class="{% if request.endpoint in ['playback_settings_page', 'player_control', 'player_info_screen'] %}active{% endif %}">Wiedergabe</a>
+        <a href="{{ url_for('network_settings') }}" class="{% if request.endpoint in ['network_settings', 'update_network'] %}active{% endif %}">Netzwerk</a>
+        <a href="{{ url_for('system_settings') }}" class="{% if request.endpoint in ['system_settings', 'system_update', 'system_service', 'system_reboot', 'system_shutdown'] %}active{% endif %}">System</a>
         <a href="{{ url_for('logout') }}">Logout</a>
       </nav>
     </header>

--- a/slideshow/templates/media.html
+++ b/slideshow/templates/media.html
@@ -1,0 +1,91 @@
+{% extends 'layout.html' %}
+{% block title %}Medienquellen – Slideshow{% endblock %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Verfügbare Quellen</h2>
+    <p class="muted">Alle Quellen mit aktiviertem automatischem Abgleich werden regelmäßig eingehängt und nach neuen Medien durchsucht.</p>
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Typ</th>
+            <th>Mountpunkt</th>
+            <th>Automatisch</th>
+            <th>Dateien</th>
+            <th>Aktionen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for source in sources %}
+          <tr>
+            <td>{{ source.name }}</td>
+            <td>{{ source.type }}</td>
+            <td><code>{{ source.path }}</code></td>
+            <td>{% if source.auto_scan %}Ja{% else %}Nein{% endif %}</td>
+            <td>
+              {% if auto_totals.get(source.name) is not none %}
+                {{ auto_totals[source.name] }}
+              {% else %}
+                –
+              {% endif %}
+            </td>
+            <td>
+              <div class="table-actions">
+                <form method="post" action="{{ url_for('toggle_auto_scan', name=source.name) }}">
+                  {% if source.auto_scan %}
+                  <input type="hidden" name="enabled" value="0" />
+                  <button type="submit">Automatik deaktivieren</button>
+                  {% else %}
+                  <input type="hidden" name="enabled" value="1" />
+                  <button type="submit">Automatik aktivieren</button>
+                  {% endif %}
+                </form>
+                {% if source.type != 'local' %}
+                <form method="post" action="{{ url_for('delete_source', name=source.name) }}" onsubmit="return confirm('Quelle {{ source.name }} wirklich löschen?');">
+                  <input type="hidden" name="confirm" value="1" />
+                  <button type="submit" class="danger">Löschen</button>
+                </form>
+                {% endif %}
+              </div>
+            </td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="6">Keine Quellen konfiguriert.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+
+  <article>
+    <h2>SMB-Quelle hinzufügen</h2>
+    <form method="post" action="{{ url_for('add_smb_source') }}" class="grid-form">
+      <label>Bezeichnung
+        <input type="text" name="name" placeholder="z. B. Produktion" required />
+      </label>
+      <label>SMB-Pfad
+        <input type="text" name="smb_path" placeholder="\\\\192.168.150.10\\Software\\RPI-Test\\1" />
+      </label>
+      <label>Domäne (optional)
+        <input type="text" name="domain" placeholder="MEINE-DOM" />
+        <small class="muted">Nur erforderlich, wenn die Anmeldung über eine Windows-Domäne erfolgt.</small>
+      </label>
+      <label>Benutzername (optional)
+        <input type="text" name="username" placeholder="z. B. administrator" />
+      </label>
+      <label>Passwort
+        <input type="password" name="password" />
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="auto_scan" value="1" checked /> Automatisch synchronisieren
+      </label>
+      <button type="submit">Quelle speichern</button>
+    </form>
+    <p class="muted">Die Pfadangabe darf optional Unterordner enthalten (z.&nbsp;B. <code>\\\\server\\share\\bilder</code>); sie werden automatisch erkannt.</p>
+  </article>
+</section>
+{% endblock %}

--- a/slideshow/templates/network.html
+++ b/slideshow/templates/network.html
@@ -1,0 +1,43 @@
+{% extends 'layout.html' %}
+{% block title %}Netzwerk – Slideshow{% endblock %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Netzwerkkonfiguration</h2>
+    <p class="muted">Änderungen am Netzwerk erfordern Administratorrechte und führen ggf. zu einer kurzfristigen Unterbrechung der Verbindung.</p>
+    <form method="post" action="{{ url_for('update_network') }}" class="grid-form">
+      <label>Hostname
+        <input type="text" name="hostname" value="{{ config.network.hostname or '' }}" placeholder="raspberrypi" />
+      </label>
+      <label>Interface
+        <input type="text" name="interface" value="{{ config.network.interface }}" />
+      </label>
+      <label>Modus
+        <select name="mode">
+          <option value="dhcp" {% if config.network.mode == 'dhcp' %}selected{% endif %}>DHCP</option>
+          <option value="static" {% if config.network.mode == 'static' %}selected{% endif %}>Statisch</option>
+        </select>
+      </label>
+      <label>Statische Adresse (CIDR)
+        <input type="text" name="address" value="{{ config.network.static.address }}" />
+      </label>
+      <label>Gateway
+        <input type="text" name="router" value="{{ config.network.static.router }}" />
+      </label>
+      <label>DNS-Server (kommagetrennt)
+        <input type="text" name="dns" value="{{ config.network.static.dns | join(',') }}" />
+      </label>
+      <button type="submit">Einstellungen übernehmen</button>
+    </form>
+  </article>
+
+  <article>
+    <h2>Hinweise</h2>
+    <ul class="hint-list">
+      <li>Bei einer statischen Konfiguration sollten Adresse, Gateway und DNS-Server in demselben Subnetz liegen.</li>
+      <li>Nach Änderungen empfiehlt sich ein kurzer Neustart der Netzwerkverbindung oder des Systems.</li>
+      <li>Der aktuelle Hostname lautet <strong>{{ config.network.hostname or 'unbekannt' }}</strong>.</li>
+    </ul>
+  </article>
+</section>
+{% endblock %}

--- a/slideshow/templates/playback.html
+++ b/slideshow/templates/playback.html
@@ -1,0 +1,124 @@
+{% extends 'layout.html' %}
+{% block title %}Wiedergabe – Slideshow{% endblock %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Steuerung</h2>
+    <div class="button-row">
+      <form method="post" action="{{ url_for('player_control', action='start') }}">
+        <button type="submit">Slideshow starten</button>
+      </form>
+      <form method="post" action="{{ url_for('player_control', action='stop') }}">
+        <button type="submit">Slideshow stoppen</button>
+      </form>
+      <form method="post" action="{{ url_for('player_control', action='reload') }}">
+        <button type="submit">Playlist neu laden</button>
+      </form>
+    </div>
+    <form method="post" action="{{ url_for('player_info_screen') }}">
+      <p class="muted">Aktueller Status: {% if state and state.info_manual %}Infobildschirm wurde manuell aktiviert{% else %}Infobildschirm ist deaktiviert{% endif %}.</p>
+      {% if config.playback.info_screen_enabled and not config.playback.splitscreen_enabled %}
+      <p class="muted">Der Infobildschirm erscheint automatisch, sobald keine Medien gefunden werden.</p>
+      {% endif %}
+      {% if state and state.info_manual %}
+      <input type="hidden" name="enabled" value="0" />
+      <button type="submit">Infobildschirm deaktivieren</button>
+      {% else %}
+      <input type="hidden" name="enabled" value="1" />
+      <button type="submit">Infobildschirm aktivieren</button>
+      {% endif %}
+    </form>
+  </article>
+
+  <article>
+    <h2>Einstellungen</h2>
+    <form method="post" action="{{ url_for('update_playback_settings') }}" class="grid-form">
+      <label>Bilddauer (Sekunden)
+        <input type="number" name="image_duration" min="1" value="{{ config.playback.image_duration }}" required />
+      </label>
+      <label>Bilddarstellung
+        <select name="image_fit">
+          <option value="contain" {% if config.playback.image_fit == 'contain' %}selected{% endif %}>Einpassen (mit Rändern)</option>
+          <option value="stretch" {% if config.playback.image_fit == 'stretch' %}selected{% endif %}>Strecken</option>
+          <option value="original" {% if config.playback.image_fit == 'original' %}selected{% endif %}>Originalgröße</option>
+        </select>
+      </label>
+      <label>Rotation (°)
+        <input type="number" name="image_rotation" min="0" max="359" value="{{ config.playback.image_rotation }}" />
+      </label>
+      <label>Übergang
+        <select name="transition_type">
+          <option value="none" {% if config.playback.transition_type == 'none' %}selected{% endif %}>Keiner</option>
+          <option value="fade" {% if config.playback.transition_type == 'fade' %}selected{% endif %}>Fade</option>
+          <option value="slide" {% if config.playback.transition_type == 'slide' %}selected{% endif %}>Slide</option>
+        </select>
+      </label>
+      <label>Übergangsdauer (Sekunden)
+        <input type="number" step="0.1" min="0.2" max="10" name="transition_duration" value="{{ config.playback.transition_duration }}" />
+      </label>
+      <label>Anzeigeauflösung
+        <input type="text" name="display_resolution" value="{{ config.playback.display_resolution }}" />
+      </label>
+      <label>Video-Ausgabemodus
+        <select name="video_backend">
+          <option value="auto" {% if config.playback.video_backend == 'auto' %}selected{% endif %}>Automatisch</option>
+          <option value="x11" {% if config.playback.video_backend == 'x11' %}selected{% endif %}>X11 / Desktop</option>
+          <option value="drm" {% if config.playback.video_backend == 'drm' %}selected{% endif %}>DRM / Framebuffer</option>
+        </select>
+      </label>
+      <label>Zusätzliche Video-Argumente
+        <textarea name="video_player_args" rows="3" placeholder="z. B. --vo=gpu">{{ config.playback.video_player_args | default([], true) | join('\n') }}</textarea>
+        <small class="muted">Ein Argument pro Zeile; leer lassen, um die Standardwerte zu verwenden.</small>
+      </label>
+      <label>Bild-Ausgabemodus
+        <select name="image_backend">
+          <option value="auto" {% if config.playback.image_backend == 'auto' %}selected{% endif %}>Automatisch</option>
+          <option value="x11" {% if config.playback.image_backend == 'x11' %}selected{% endif %}>X11 / Desktop</option>
+          <option value="drm" {% if config.playback.image_backend == 'drm' %}selected{% endif %}>DRM / Framebuffer</option>
+        </select>
+      </label>
+      <label>Zusätzliche Bild-Argumente
+        <textarea name="image_viewer_args" rows="3" placeholder="z. B. --vo=gpu">{{ config.playback.image_viewer_args | default([], true) | join('\n') }}</textarea>
+        <small class="muted">Ein Argument pro Zeile. Für DRM werden Geometrie-Optionen ignoriert.</small>
+      </label>
+      <fieldset class="splitscreen">
+        <legend>Splitscreen</legend>
+        <label class="checkbox">
+          <input type="checkbox" name="splitscreen_enabled" value="1" {% if config.playback.splitscreen_enabled %}checked{% endif %} /> Aktivieren
+        </label>
+        <div class="split-grid">
+          <div>
+            <h4>Linke Seite</h4>
+            <label>Quelle
+              <select name="splitscreen_left_source">
+                <option value="">(keine)</option>
+                {% for source in sources %}
+                <option value="{{ source.name }}" {% if config.playback.splitscreen_left_source == source.name %}selected{% endif %}>{{ source.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>Pfad (optional)
+              <input type="text" name="splitscreen_left_path" value="{{ config.playback.splitscreen_left_path }}" />
+            </label>
+          </div>
+          <div>
+            <h4>Rechte Seite</h4>
+            <label>Quelle
+              <select name="splitscreen_right_source">
+                <option value="">(keine)</option>
+                {% for source in sources %}
+                <option value="{{ source.name }}" {% if config.playback.splitscreen_right_source == source.name %}selected{% endif %}>{{ source.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>Pfad (optional)
+              <input type="text" name="splitscreen_right_path" value="{{ config.playback.splitscreen_right_path }}" />
+            </label>
+          </div>
+        </div>
+      </fieldset>
+      <button type="submit">Einstellungen speichern</button>
+    </form>
+  </article>
+</section>
+{% endblock %}

--- a/slideshow/templates/system.html
+++ b/slideshow/templates/system.html
@@ -1,0 +1,122 @@
+{% extends 'layout.html' %}
+{% block title %}System – Slideshow{% endblock %}
+{% block content %}
+<section class="grid system-grid">
+  <article>
+    <h2>Updates</h2>
+    {% if has_branch_info %}
+    <form method="post" action="{{ url_for('system_update') }}" class="grid-form">
+      <label>Branch auswählen
+        <select name="branch">
+          {% set displayed = false %}
+          {% for branch in branches %}
+            {% set displayed = true %}
+            <option value="{{ branch }}" {% if current_branch and branch == current_branch %}selected{% endif %}>{{ branch }}</option>
+          {% endfor %}
+          {% if not displayed and current_branch %}
+            <option value="{{ current_branch }}" selected>{{ current_branch }}</option>
+          {% endif %}
+        </select>
+      </label>
+      <button type="submit">Update starten</button>
+    </form>
+    <p class="muted">Aktueller Branch: <strong>{{ current_branch or 'unbekannt' }}</strong></p>
+    {% else %}
+    <p class="muted">Git-Updates stehen in dieser Installation nicht zur Verfügung. Stelle sicher, dass das Repository über Git installiert wurde{% if fallback_repo %} oder prüfe die veröffentlichten Versionen unter <a href="https://github.com/{{ fallback_repo }}/branches" target="_blank" rel="noopener">GitHub</a>{% endif %}.</p>
+    {% endif %}
+  </article>
+
+  <article>
+    <h2>Service &amp; Aktionen</h2>
+    <p><strong>Service-Status:</strong> {{ service_status or 'unbekannt' }}</p>
+    <div class="button-row">
+      <form method="post" action="{{ url_for('system_service', action='restart') }}">
+        <button type="submit">Service neu starten</button>
+      </form>
+      <form method="post" action="{{ url_for('system_service', action='start') }}">
+        <button type="submit">Service starten</button>
+      </form>
+      <form method="post" action="{{ url_for('system_service', action='stop') }}">
+        <button type="submit">Service stoppen</button>
+      </form>
+    </div>
+    <div class="button-row">
+      <form method="post" action="{{ url_for('system_reboot') }}" onsubmit="return confirm('Raspberry Pi wirklich neu starten?');">
+        <button type="submit">Raspberry Pi neu starten</button>
+      </form>
+      <form method="post" action="{{ url_for('system_shutdown') }}" onsubmit="return confirm('Raspberry Pi herunterfahren?');">
+        <button type="submit" class="danger">Herunterfahren</button>
+      </form>
+    </div>
+  </article>
+
+  <article class="logs">
+    <h2>Protokolle</h2>
+    <div class="log-controls">
+      <label>Log auswählen
+        <select id="log-select">
+          {% for key, info in log_sources.items() %}
+          <option value="{{ key }}">{{ info.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Zeilen
+        <input type="number" id="log-lines" value="200" min="10" max="2000" />
+      </label>
+      <button type="button" id="log-refresh">Aktualisieren</button>
+    </div>
+    <pre id="log-output">Wähle ein Log aus, um den Inhalt zu laden.</pre>
+  </article>
+</section>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const select = document.getElementById('log-select');
+    const output = document.getElementById('log-output');
+    const linesInput = document.getElementById('log-lines');
+    const refresh = document.getElementById('log-refresh');
+    const baseUrl = "{{ url_for('show_log', name='__LOG__') }}";
+
+    async function loadLog() {
+      if (!select || !output) {
+        return;
+      }
+      const name = select.value;
+      const lines = linesInput && linesInput.value ? linesInput.value : '200';
+      if (!name) {
+        output.textContent = 'Keine Logdatei ausgewählt.';
+        return;
+      }
+      output.textContent = 'Lade Log …';
+      try {
+        const response = await fetch(baseUrl.replace('__LOG__', encodeURIComponent(name)) + `?lines=${encodeURIComponent(lines)}`);
+        if (!response.ok) {
+          output.textContent = `Fehler beim Laden (${response.status})`;
+          return;
+        }
+        const text = await response.text();
+        output.textContent = text || 'Keine Einträge vorhanden.';
+      } catch (error) {
+        output.textContent = 'Fehler beim Abrufen des Logs.';
+      }
+    }
+
+    if (refresh) {
+      refresh.addEventListener('click', loadLog);
+    }
+    if (select) {
+      select.addEventListener('change', loadLog);
+    }
+    if (linesInput) {
+      linesInput.addEventListener('change', loadLog);
+    }
+
+    if (select && select.value) {
+      loadLog();
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add optional video/render/input group enrollment for the slideshow service account and report missing device groups during installation
- replace the one-time Xauthority copy with a reusable prestart helper that syncs the cookie, waits for the desktop session, and logs display availability without aborting the service
- document the new group handling and prestart behavior for desktop deployments

## Testing
- python -m compileall slideshow

------
https://chatgpt.com/codex/tasks/task_e_68df21302f78832d9852abca7b5e6d9f