### PR TITLE
Remove headless playback support and tighten desktop startup checks

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,37 +5,21 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Verwendung: install.sh [--drm] [--video-backend NAME] [--desktop-user NAME] [--service-user NAME]
+Verwendung: install.sh [--desktop-user NAME]
 
 Optionen:
-  --drm                Aktiviert die Framebuffer-/DRM-Ausgabe (kein Desktop erforderlich).
-  --video-backend NAME Setzt das Backend explizit auf "x11" oder "drm".
   --desktop-user NAME  Legt das Benutzerkonto fest, unter dem Dienst und Desktop laufen.
   --help               Zeigt diese Hilfe an.
 EOF
 }
 
-VIDEO_BACKEND="${SLIDESHOW_VIDEO_BACKEND:-x11}"
 DESKTOP_USER_ARG=""
-SERVICE_USER_ARG=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --drm)
-      VIDEO_BACKEND="drm"
-      shift
-      ;;
-    --video-backend)
-      VIDEO_BACKEND="${2:-}"
-      shift 2 || { echo "--video-backend benötigt einen Wert" >&2; exit 1; }
-      ;;
     --desktop-user)
       DESKTOP_USER_ARG="${2:-}"
       shift 2 || { echo "--desktop-user benötigt einen Wert" >&2; exit 1; }
-      ;;
-    --service-user)
-      SERVICE_USER_ARG="${2:-}"
-      shift 2 || { echo "--service-user benötigt einen Wert" >&2; exit 1; }
       ;;
     --help)
       usage
@@ -49,12 +33,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-VIDEO_BACKEND="${VIDEO_BACKEND,,}"
-if [[ "$VIDEO_BACKEND" != "drm" && "$VIDEO_BACKEND" != "x11" ]]; then
-  echo "Unbekanntes Backend '$VIDEO_BACKEND', verwende x11." >&2
-  VIDEO_BACKEND="x11"
-fi
-
 APP_DIR="/opt/slideshow"
 VENV_DIR="$APP_DIR/.venv"
 SERVICE_FILE="/etc/systemd/system/slideshow.service"
@@ -64,7 +42,7 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-echo "Installationsmodus: Backend=$VIDEO_BACKEND"
+echo "Installationsmodus: Desktop (X11)"
 
 REPO_SLUG=$(grep -m1 '^# REPO_SLUG:' "$0" | awk -F':' '{print $2}' | xargs)
 REPO_SLUG="${REPO_SLUG:-${SLIDESHOW_REPO_SLUG:-joni123467/Slideshow}}"
@@ -72,14 +50,8 @@ REPO_URL="https://github.com/${REPO_SLUG}.git"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-COMMON_PACKAGES=(git python3 python3-venv python3-pip rsync cifs-utils ffmpeg mpv feh curl ca-certificates)
-EXTRA_PACKAGES=()
-if [[ "$VIDEO_BACKEND" == "x11" ]]; then
-  EXTRA_PACKAGES+=(x11-xserver-utils)
-else
-  EXTRA_PACKAGES+=(mesa-utils libdrm2 libgbm1)
-fi
-apt-get install -y "${COMMON_PACKAGES[@]}" "${EXTRA_PACKAGES[@]}"
+COMMON_PACKAGES=(git python3 python3-venv python3-pip rsync cifs-utils ffmpeg mpv feh curl ca-certificates x11-xserver-utils)
+apt-get install -y "${COMMON_PACKAGES[@]}"
 
 determine_latest_branch() {
   local url="$1"
@@ -140,13 +112,7 @@ fi
 
 echo "Verwende bestehenden Benutzer $USER_NAME für Dienst und Desktop-Integration."
 
-DESKTOP_USER=""
-if [[ "$VIDEO_BACKEND" == "x11" ]]; then
-  DESKTOP_USER="$USER_NAME"
-fi
-if [[ "$VIDEO_BACKEND" == "drm" ]]; then
-  echo "DRM-Modus: Desktop-Integration optional, Dienst läuft trotzdem als $USER_NAME."
-fi
+DESKTOP_USER="$USER_NAME"
 
 GROUP_ADDED=()
 GROUP_MISSING=()
@@ -239,8 +205,6 @@ SERVICE_ENV=(
   "Environment=PYTHONUNBUFFERED=1"
   "Environment=XDG_RUNTIME_DIR=$RUNTIME_DIR"
   "Environment=SLIDESHOW_SERVICE_USER=$USER_NAME"
-  "Environment=SLIDESHOW_VIDEO_BACKEND=$VIDEO_BACKEND"
-  "Environment=SLIDESHOW_IMAGE_BACKEND=$VIDEO_BACKEND"
 )
 if [[ -n "$XAUTHORITY_SOURCE" ]]; then
   SERVICE_ENV+=("Environment=SLIDESHOW_XAUTHORITY_SOURCE=$XAUTHORITY_SOURCE")
@@ -271,7 +235,7 @@ fi
   done
   echo "ExecStartPre=$APP_DIR/scripts/prestart.sh"
   echo "ExecStart=$VENV_DIR/bin/python manage.py run --host 0.0.0.0 --port 8080"
-  echo "ExecStartPost=/bin/sh -c 'if [ -n \"\$DISPLAY\" ]; then echo \"Slideshow mit DISPLAY=\$DISPLAY gestartet (Backend: \$SLIDESHOW_VIDEO_BACKEND)\" | systemd-cat -t slideshow; else echo \"Slideshow im Headless-Modus gestartet\" | systemd-cat -t slideshow; fi'"
+  echo "ExecStartPost=/bin/sh -c 'echo \"Slideshow mit DISPLAY=\$DISPLAY gestartet\" | systemd-cat -t slideshow'"
   echo "Restart=on-failure"
   echo "RestartSec=5"
   echo ""
@@ -302,8 +266,7 @@ Installation abgeschlossen.
 Repository: $REPO_URL
 Branch: $BRANCH
 Dienst-/Desktop-Benutzer: $USER_NAME
-Video-Backend: $VIDEO_BACKEND
-Desktop-Anzeige: ${DESKTOP_USER:-keine}
+Desktop-Anzeige: $DESKTOP_USER
 $GROUP_SUMMARY
 ${GROUP_MISSING_NOTICE:-}
 INFO

--- a/scripts/prestart.sh
+++ b/scripts/prestart.sh
@@ -12,21 +12,27 @@ fi
 
 if [[ -n "${SLIDESHOW_XAUTHORITY_SOURCE:-}" && -n "${XAUTHORITY:-}" ]]; then
   if [[ -f "$SLIDESHOW_XAUTHORITY_SOURCE" ]]; then
-    install -m 600 -o "$SERVICE_USER" -g "$SERVICE_USER" "$SLIDESHOW_XAUTHORITY_SOURCE" "$XAUTHORITY"
-    log "Xauthority von $SLIDESHOW_XAUTHORITY_SOURCE nach $XAUTHORITY synchronisiert."
+    SRC_CANON="$(realpath -m "$SLIDESHOW_XAUTHORITY_SOURCE")"
+    DEST_CANON="$(realpath -m "$XAUTHORITY")"
+    if [[ "$SRC_CANON" == "$DEST_CANON" ]]; then
+      log "Xauthority-Quelle ($SRC_CANON) entspricht dem Ziel – keine Synchronisation erforderlich."
+    else
+      install -m 600 -o "$SERVICE_USER" -g "$SERVICE_USER" "$SLIDESHOW_XAUTHORITY_SOURCE" "$XAUTHORITY"
+      log "Xauthority von $SLIDESHOW_XAUTHORITY_SOURCE nach $XAUTHORITY synchronisiert."
+    fi
   else
     log "Warnung: Xauthority-Quelle $SLIDESHOW_XAUTHORITY_SOURCE wurde nicht gefunden."
   fi
 fi
 
 if [[ -z "${DISPLAY:-}" ]]; then
-  log "Kein DISPLAY gesetzt – headless Start."
-  exit 0
+  log "Fehler: DISPLAY ist nicht gesetzt. Der Desktop muss aktiv sein."
+  exit 1
 fi
 
 if ! command -v xset >/dev/null 2>&1; then
-  log "xset nicht verfügbar – überspringe Anzeigeprüfung."
-  exit 0
+  log "Fehler: xset ist nicht verfügbar. Bitte Desktop-Paket x11-xserver-utils installieren."
+  exit 1
 fi
 
 CHECK_OK=0
@@ -51,8 +57,8 @@ done
 
 if [[ "$CHECK_OK" -eq 1 ]]; then
   log "Display $DISPLAY ist erreichbar."
-else
-  log "Display $DISPLAY blieb unerreichbar; Dienst startet dennoch."
+  exit 0
 fi
 
-exit 0
+log "Fehler: Display $DISPLAY war nicht erreichbar."
+exit 1

--- a/slideshow/app.py
+++ b/slideshow/app.py
@@ -347,16 +347,6 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         display_resolution = (request.form.get("display_resolution") or playback.display_resolution).strip()
         playback.display_resolution = display_resolution
 
-        video_backend = (request.form.get("video_backend") or playback.video_backend or "auto").lower()
-        if video_backend not in {"auto", "x11", "drm"}:
-            video_backend = "auto"
-        playback.video_backend = video_backend
-
-        image_backend = (request.form.get("image_backend") or playback.image_backend or video_backend).lower()
-        if image_backend not in {"auto", "x11", "drm"}:
-            image_backend = video_backend
-        playback.image_backend = image_backend
-
         playback.video_player_args = parse_args("video_player_args", playback.video_player_args)
         playback.image_viewer_args = parse_args("image_viewer_args", playback.image_viewer_args)
 

--- a/slideshow/config.py
+++ b/slideshow/config.py
@@ -58,8 +58,6 @@ DEFAULT_CONFIG = {
         "image_duration": 10,
         "video_player": "mpv",
         "image_viewer": "mpv",
-        "video_backend": "auto",
-        "image_backend": "auto",
         "video_player_args": [],
         "image_viewer_args": [],
         "auto_start": True,
@@ -126,8 +124,6 @@ class PlaybackConfig:
     image_duration: int
     video_player: str
     image_viewer: str
-    video_backend: str
-    image_backend: str
     video_player_args: List[str]
     image_viewer_args: List[str]
     auto_start: bool
@@ -168,6 +164,9 @@ class AppConfig:
             with CONFIG_PATH.open("r", encoding="utf-8") as fh:
                 raw = yaml.safe_load(fh) or {}
         config = _merge_dict(DEFAULT_CONFIG, raw)
+        playback_raw = dict(config["playback"])
+        playback_raw.pop("video_backend", None)
+        playback_raw.pop("image_backend", None)
         instance = cls(
             media_sources=[
                 MediaSource(
@@ -181,7 +180,7 @@ class AppConfig:
                 for src in config["media_sources"]
             ],
             playlist=[PlaylistItem(**item) for item in config["playlist"]],
-            playback=PlaybackConfig(**config["playback"]),
+            playback=PlaybackConfig(**playback_raw),
             network=NetworkConfig(**config["network"]),
             server=ServerConfig(**config["server"]),
         )
@@ -221,8 +220,6 @@ class AppConfig:
 
         self.playback.video_player_args = _normalize_str_list(self.playback.video_player_args)
         self.playback.image_viewer_args = _normalize_str_list(self.playback.image_viewer_args)
-        self.playback.video_backend = (self.playback.video_backend or "auto").lower()
-        self.playback.image_backend = (self.playback.image_backend or "auto").lower()
 
 
 def _normalize_str_list(value: Any) -> List[str]:

--- a/slideshow/templates/playback.html
+++ b/slideshow/templates/playback.html
@@ -59,27 +59,13 @@
       <label>Anzeigeauflösung
         <input type="text" name="display_resolution" value="{{ config.playback.display_resolution }}" />
       </label>
-      <label>Video-Ausgabemodus
-        <select name="video_backend">
-          <option value="auto" {% if config.playback.video_backend == 'auto' %}selected{% endif %}>Automatisch</option>
-          <option value="x11" {% if config.playback.video_backend == 'x11' %}selected{% endif %}>X11 / Desktop</option>
-          <option value="drm" {% if config.playback.video_backend == 'drm' %}selected{% endif %}>DRM / Framebuffer</option>
-        </select>
-      </label>
       <label>Zusätzliche Video-Argumente
         <textarea name="video_player_args" rows="3" placeholder="z. B. --vo=gpu">{{ config.playback.video_player_args | default([], true) | join('\n') }}</textarea>
         <small class="muted">Ein Argument pro Zeile; leer lassen, um die Standardwerte zu verwenden.</small>
       </label>
-      <label>Bild-Ausgabemodus
-        <select name="image_backend">
-          <option value="auto" {% if config.playback.image_backend == 'auto' %}selected{% endif %}>Automatisch</option>
-          <option value="x11" {% if config.playback.image_backend == 'x11' %}selected{% endif %}>X11 / Desktop</option>
-          <option value="drm" {% if config.playback.image_backend == 'drm' %}selected{% endif %}>DRM / Framebuffer</option>
-        </select>
-      </label>
       <label>Zusätzliche Bild-Argumente
         <textarea name="image_viewer_args" rows="3" placeholder="z. B. --vo=gpu">{{ config.playback.image_viewer_args | default([], true) | join('\n') }}</textarea>
-        <small class="muted">Ein Argument pro Zeile. Für DRM werden Geometrie-Optionen ignoriert.</small>
+        <small class="muted">Ein Argument pro Zeile.</small>
       </label>
       <fieldset class="splitscreen">
         <legend>Splitscreen</legend>


### PR DESCRIPTION
## Summary
- drop the DRM/headless installation path, enforce the desktop workflow, and update the documentation accordingly
- ensure the pre-start script skips redundant Xauthority copies and aborts when no X11 session is available
- simplify the player to always launch mpv with X11 windowing options and remove backend toggles from the UI

## Testing
- python -m compileall slideshow

------
https://chatgpt.com/codex/tasks/task_e_68df55ff6da4832dba662222850bec4e