### PR TITLE
Improve dashboard previews and splitscreen controls

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,140 @@
+# Slideshow REST- und Hilfs-API
+
+Die Weboberfläche stellt mehrere JSON-Endpunkte bereit, die nach einer erfolgreichen Anmeldung (Session-Cookie via `/login`) genutzt werden können. Alle Antworten verwenden UTF-8 und den MIME-Type `application/json`, sofern nicht anders angegeben.
+
+## Authentifizierung
+
+* **Login:** `POST /login` mit den Formularfeldern `username` und `password`. Bei Erfolg wird ein Session-Cookie gesetzt, das für alle API-Aufrufe benötigt wird.
+* **Logout:** `GET /logout` beendet die Session.
+
+## Status-Endpunkte
+
+### `GET /api/state`
+
+Aktueller Wiedergabestatus.
+
+```json
+{
+  "primary_item": "Pfad/zur/datei.jpg",
+  "primary_status": "playing",
+  "primary_started_at": 1700000000.0,
+  "primary_source": "local",
+  "primary_media_path": "bilder/motiv.jpg",
+  "primary_media_type": "image",
+  "primary_preview": "/home/pi/.slideshow/cache/local/bilder/motiv.jpg",
+  "primary_preview_token": 1700000123,
+  "primary_preview_available": true,
+  "secondary_item": null,
+  "secondary_status": "stopped",
+  "secondary_started_at": null,
+  "secondary_source": null,
+  "secondary_media_type": null,
+  "secondary_preview": null,
+  "secondary_preview_token": 0,
+  "secondary_preview_available": false,
+  "info_screen": false,
+  "info_manual": false,
+  "service_status": "active",
+  "service_active": true,
+  "version": "0.0.4",
+  "theme": "mid"
+}
+```
+
+Das Feld `service_status` spiegelt den Rohwert von `systemctl is-active` wider, `service_active` ist ein boolesches Convenience-Feld. Die `*_preview`-Felder geben Pfadinformationen (falls verfügbar) und einen Cache-Busting-Zeitstempel an, sodass Clients gezielt Vorschaubilder nachladen können.
+
+### `GET /api/config`
+
+Gesamtkonfiguration in kompakter Form.
+
+* `sources` – Liste der Medienquellen (siehe `MediaSource` Felder)
+* `playlist` – Manuell konfigurierte Playlist-Einträge
+* `network` – Netzwerkkonfiguration
+* `playback` – Aktuelle Wiedergabeeinstellungen
+
+## Playersteuerung
+
+### `POST /api/player/<action>`
+
+* `action` ∈ {`start`, `stop`, `reload`}
+* Antwort: `{ "status": "ok", "action": "start" }`
+
+### `POST /api/player/info-screen`
+
+* JSON-Body: `{ "enabled": true }`
+* Schaltet den Infobildschirm dauerhaft ein/aus.
+
+## Wiedergabeeinstellungen
+
+### `PUT /api/playback`
+
+Akzeptiert ein (teilweises) JSON-Objekt mit denselben Feldern wie die Wiedergabekonfiguration. Validierte Felder werden übernommen, alle anderen bleiben unverändert.
+
+Wichtige Felder:
+
+* `image_duration` – Ganzzahl ≥ 1
+* `image_fit` – `contain`, `stretch` oder `original`
+* `image_rotation` – 0…359
+* `transition_type` – `none`, `fade`, `fadeblack`, `fadewhite`, `wipeleft`, `wiperight`, `wipeup`, `wipedown`, `slideleft`, `slideright`, `slideup`, `slidedown`
+* `transition_duration` – 0.2…10.0 Sekunden
+* `splitscreen_enabled` – Boolesch
+* `splitscreen_left_source`, `splitscreen_right_source` – Namen existierender Quellen
+* `splitscreen_left_path`, `splitscreen_right_path` – optionale Unterordner
+* `video_player_args`, `image_viewer_args` – Liste zusätzlicher Argumente
+
+Antwort: `{ "status": "ok", "playback": { ... } }`
+
+## Quellenverwaltung
+
+### `GET /api/sources`
+
+Listet alle konfigurierten Quellen: `{ "sources": [ {"name": "…", ...}, ... ] }`
+
+### `POST /api/sources`
+
+Legt eine neue SMB-Quelle an. Erwartete Felder (alle Strings):
+
+* `name` (erforderlich)
+* `server`, `share` (optional, werden überschrieben wenn `smb_path` gesetzt ist)
+* `smb_path` (optional, z. B. `\\\\server\\share\\bilder`)
+* `username`, `password`, `domain`, `subpath`
+* `auto_scan` (boolesch, Standard `true`)
+
+Antwort: `{ "status": "ok", "source": { ... } }`
+
+### `PUT /api/sources/<name>`
+
+Aktualisiert eine bestehende SMB-Quelle. Unterstützt dieselben Felder wie `POST /api/sources` plus `name` (zum Umbenennen). Wird `password` auf einen leeren String gesetzt, wird das gespeicherte Kennwort gelöscht.
+
+### `DELETE /api/sources/<name>`
+
+Entfernt eine Quelle (die lokale Standardquelle ist geschützt).
+
+## Medienvorschauen
+
+### `GET /media/preview/<source>/<path>`
+
+Liefert ein kleines JPEG-Vorschaubild für Bilddateien einer Quelle. Für andere Dateitypen wird HTTP 415 zurückgegeben. Der Endpunkt ist authentifizierungspflichtig und hauptsächlich für die Dashboard-Anzeige gedacht.
+
+### `GET /logs/<name>/download`
+
+Lädt eine komplette Logdatei als Text herunter. Der Parameter `<name>` entspricht einem Schlüssel aus der Logauswahl des System-Tabs (`app`, `player`, `media`, `network`, `system`).
+
+## Systemverwaltung
+
+### `GET /config/export`
+
+Lädt die aktuelle Konfiguration (inklusive `config.yml` und optional `secrets.json`, falls vorhanden) als ZIP-Archiv herunter.
+
+### `POST /config/import`
+
+Erwartet ein Multipart-Formular mit dem Feld `config_file`. Akzeptiert entweder das zuvor exportierte ZIP-Archiv oder eine einzelne `config.yml`. Nach erfolgreichem Import werden Player- und Netzwerkverwaltung neu initialisiert.
+
+## Fehlercodes
+
+* `400 Bad Request` – Eingabedaten fehlerhaft oder unvollständig
+* `404 Not Found` – Quelle/Datei nicht vorhanden
+* `415 Unsupported Media Type` – Vorschau für Datei nicht verfügbar
+* `500 Internal Server Error` – Unerwarteter Fehler (Log prüfen)
+
+Alle Fehlerantworten enthalten ein JSON-Objekt `{ "status": "error", "message": "…" }` mit einer kurzen Beschreibung.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "slideshow"
-version = "0.0.2"
+version = "0.0.4"
 description = "Raspberry Pi slideshow service with web configuration"
 authors = ["Slideshow Maintainers <maintainers@example.com>"]
 readme = "README.md"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -142,6 +142,10 @@ cat <<BRANCH > "$APP_DIR/.install_branch"
 $BRANCH
 BRANCH
 
+cat <<REPO > "$APP_DIR/.install_repo"
+$REPO_SLUG
+REPO
+
 chmod +x "$APP_DIR/scripts/update.sh" "$APP_DIR/scripts/mount_smb.sh" 2>/dev/null || true
 
 SUDOERS_FILE="/etc/sudoers.d/slideshow"

--- a/slideshow/__init__.py
+++ b/slideshow/__init__.py
@@ -1,9 +1,37 @@
 """Slideshow Package."""
+from __future__ import annotations
+
+import pathlib
+
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:  # pragma: no cover - fallback für ältere Python-Versionen
+    import importlib_metadata  # type: ignore[no-redef]
+
 from .logging_config import configure_logging
+
+
+def _discover_version() -> str:
+    project_root = pathlib.Path(__file__).resolve().parent.parent
+    pyproject = project_root / "pyproject.toml"
+    if pyproject.exists():
+        for line in pyproject.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("version"):
+                _, _, value = stripped.partition("=")
+                cleaned = value.strip().strip('"').strip("'")
+                if cleaned:
+                    return cleaned
+    package_name = "slideshow"
+    try:
+        return importlib_metadata.version(package_name)
+    except importlib_metadata.PackageNotFoundError:
+        return "0.0.0"
+
 
 configure_logging()
 
-__version__ = "0.0.1"
+__version__ = _discover_version()
 
 from .app import create_app
 

--- a/slideshow/app.py
+++ b/slideshow/app.py
@@ -1,17 +1,33 @@
 """Flask-Anwendung für die Slideshow."""
 from __future__ import annotations
 
+import dataclasses
+import datetime
 import functools
+import io
 import logging
+import mimetypes
+import pathlib
 import subprocess
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
-from flask import Flask, Response, abort, flash, jsonify, redirect, render_template, request, url_for
+from flask import (
+    Flask,
+    Response,
+    abort,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_login import LoginManager, current_user, login_required, login_user, logout_user
 
 from . import __version__
 from .auth import PamAuthenticator, User
-from .config import AppConfig
+from .config import AppConfig, export_config_bundle, import_config_bundle
 from .logging_config import available_logs
 from .media import MediaManager
 from .network import NetworkManager
@@ -20,6 +36,29 @@ from .state import get_state
 from .system import SystemManager
 
 LOGGER = logging.getLogger(__name__)
+
+TRANSITION_OPTIONS: Tuple[Tuple[str, str], ...] = (
+    ("none", "Keiner"),
+    ("fade", "Überblendung"),
+    ("fadeblack", "Blende zu Schwarz"),
+    ("fadewhite", "Blende zu Weiß"),
+    ("wipeleft", "Wischen nach links"),
+    ("wiperight", "Wischen nach rechts"),
+    ("wipeup", "Wischen nach oben"),
+    ("wipedown", "Wischen nach unten"),
+    ("slideleft", "Schieben nach links"),
+    ("slideright", "Schieben nach rechts"),
+    ("slideup", "Schieben nach oben"),
+    ("slidedown", "Schieben nach unten"),
+)
+
+ALLOWED_TRANSITIONS = {option for option, _ in TRANSITION_OPTIONS}
+
+THEME_CHOICES: Tuple[Tuple[str, str], ...] = (
+    ("light", "Hell"),
+    ("mid", "Neutral"),
+    ("dark", "Dunkel"),
+)
 
 
 def create_app(config: Optional[AppConfig] = None, player_service: Optional[PlayerService] = None) -> Flask:
@@ -40,13 +79,30 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     app.extensions["player_service"] = player
     app.extensions["system_manager"] = system_manager
     app.config["SLIDESHOW_VERSION"] = __version__
+    app.config["SLIDESHOW_THEME"] = cfg.ui.theme
+
+    def _preview_token(path_str: Optional[str]) -> int:
+        if not path_str:
+            return 0
+        try:
+            return int(pathlib.Path(path_str).stat().st_mtime)
+        except OSError:
+            return 0
 
     @app.context_processor
     def inject_globals():
         return {
             "slideshow_version": app.config.get("SLIDESHOW_VERSION", "0.0.0"),
             "log_sources": available_logs(),
+            "current_theme": cfg.ui.theme,
+            "theme_choices": THEME_CHOICES,
         }
+
+    def service_active(status: Optional[str]) -> bool:
+        if not status:
+            return False
+        normalized = status.strip().lower()
+        return normalized in {"active", "active (running)", "running"}
 
     @app.template_filter("datetimeformat")
     def datetimeformat(value, fmt="%d.%m.%Y %H:%M:%S"):
@@ -107,7 +163,52 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             playlist=playlist_preview,
             config=cfg,
             service_status=service_status,
+            service_active=service_active(service_status),
         )
+
+    @app.route("/media/preview/<string:source>/<path:media_path>")
+    @pam_required
+    def media_preview(source: str, media_path: str):
+        try:
+            content, mime = media_manager.generate_preview(source, media_path)
+        except TypeError:
+            abort(415)
+        except (ValueError, FileNotFoundError, PermissionError):
+            abort(404)
+        response = Response(content, mimetype=mime)
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return response
+
+    @app.route("/state/preview/<string:side>")
+    @pam_required
+    def state_preview(side: str):
+        normalized = side.lower()
+        if normalized not in {"primary", "secondary"}:
+            abort(404)
+        state = get_state()
+        preview_path = (
+            state.primary_preview if normalized == "primary" else state.secondary_preview
+        )
+        media_type = (
+            state.primary_media_type if normalized == "primary" else state.secondary_media_type
+        )
+        if not preview_path or media_type not in {"image", "info"}:
+            abort(404)
+        path = pathlib.Path(preview_path)
+        if not path.exists() or not path.is_file():
+            abort(404)
+        mime, _ = mimetypes.guess_type(str(path))
+        try:
+            response = send_file(
+                path,
+                mimetype=mime or "image/png",
+                as_attachment=False,
+                conditional=True,
+            )
+        except FileNotFoundError:
+            abort(404)
+        response.headers["Cache-Control"] = "no-store, max-age=0"
+        return response
 
     @app.route("/media")
     @pam_required
@@ -131,6 +232,69 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             config=cfg,
         )
 
+    @app.route("/sources/<path:name>/edit", methods=["GET", "POST"])
+    @pam_required
+    def edit_source(name: str):
+        source = cfg.get_source(name)
+        if not source or source.type != "smb":
+            abort(404)
+
+        if request.method == "POST":
+            new_name = (request.form.get("name") or "").strip() or source.name
+            smb_path = (request.form.get("smb_path") or "").strip() or None
+            server = (request.form.get("server") or "").strip() or None
+            share = (request.form.get("share") or "").strip() or None
+            username = (request.form.get("username") or "").strip()
+            domain = (request.form.get("domain") or "").strip()
+            subpath = (request.form.get("subpath") or "").strip() or None
+            auto_scan = request.form.get("auto_scan") is not None
+            password_raw = request.form.get("password")
+            password_action = request.form.get("clear_password")
+            password: Optional[str]
+            if password_action == "1":
+                password = ""
+            elif password_raw:
+                password = password_raw
+            else:
+                password = None
+
+            try:
+                media_manager.update_source(
+                    name,
+                    new_name=new_name,
+                    smb_path=smb_path,
+                    server=server,
+                    share=share,
+                    username=username or None,
+                    password=password,
+                    domain=domain or None,
+                    subpath=subpath,
+                    auto_scan=auto_scan,
+                )
+            except ValueError as exc:
+                flash(str(exc), "danger")
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.exception("Konnte Quelle nicht aktualisieren")
+                flash(f"Aktualisierung fehlgeschlagen: {exc}", "danger")
+            else:
+                player.reload()
+                flash("Quelle aktualisiert", "success")
+                return redirect(url_for("media_settings"))
+
+        smb_prefill = request.form.get("smb_path")
+        if smb_prefill is None:
+            server_opt = source.options.get("server")
+            share_opt = source.options.get("share")
+            subpath_value = request.form.get("subpath") if request.form else source.subpath
+            if server_opt and share_opt:
+                smb_prefill = f"smb://{server_opt}/{share_opt}"
+                normalized_sub = (subpath_value or "").replace("\\", "/").strip("/")
+                if normalized_sub:
+                    smb_prefill = f"{smb_prefill.rstrip('/')}/{normalized_sub}"
+            else:
+                smb_prefill = ""
+        return render_template("edit_source.html", source=source, smb_prefill=smb_prefill or "")
+
     @app.route("/playback")
     @pam_required
     def playback_settings_page():
@@ -140,14 +304,17 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             config=cfg,
             sources=sources,
             state=get_state(),
+            transition_options=TRANSITION_OPTIONS,
         )
 
     @app.route("/network")
     @pam_required
     def network_settings():
+        current = network_manager.current_settings()
         return render_template(
             "network.html",
             config=cfg,
+            current=current,
         )
 
     @app.route("/system")
@@ -164,7 +331,73 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             has_branch_info=bool(branches or current_branch),
             fallback_repo=system_manager.fallback_repo,
             service_status=service_status,
+            service_active=service_active(service_status),
         )
+
+    @app.route("/system/theme", methods=["POST"])
+    @pam_required
+    def update_theme():
+        theme = (request.form.get("theme") or "").strip().lower()
+        allowed = {name for name, _ in THEME_CHOICES}
+        if theme not in allowed:
+            flash("Ungültiges Theme", "danger")
+            return redirect(url_for("system_settings"))
+        if theme != cfg.ui.theme:
+            cfg.ui.theme = theme
+            cfg.save()
+            app.config["SLIDESHOW_THEME"] = theme
+            flash("Theme aktualisiert", "success")
+        else:
+            flash("Theme ist bereits aktiv", "info")
+        return redirect(url_for("system_settings"))
+
+    @app.route("/config/export")
+    @pam_required
+    def export_config():
+        archive = export_config_bundle()
+        timestamp = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        filename = f"slideshow-config-{timestamp}.zip"
+        return send_file(
+            io.BytesIO(archive),
+            mimetype="application/zip",
+            as_attachment=True,
+            download_name=filename,
+        )
+
+    @app.route("/config/import", methods=["POST"])
+    @pam_required
+    def import_config():
+        nonlocal cfg, media_manager, network_manager, player
+        file = request.files.get("config_file")
+        if not file or not file.filename:
+            flash("Keine Konfigurationsdatei ausgewählt", "danger")
+            return redirect(url_for("system_settings"))
+        data = file.read()
+        if not data:
+            flash("Die hochgeladene Datei ist leer", "danger")
+            return redirect(url_for("system_settings"))
+        try:
+            new_cfg = import_config_bundle(data)
+        except ValueError as exc:
+            flash(str(exc), "danger")
+            return redirect(url_for("system_settings"))
+
+        was_running = player.is_running()
+        player.stop()
+
+        cfg = new_cfg
+        media_manager = MediaManager(cfg)
+        network_manager = NetworkManager(cfg)
+        new_player = PlayerService(cfg)
+        app.extensions["player_service"] = new_player
+        player = new_player
+        app.config["SLIDESHOW_THEME"] = cfg.ui.theme
+
+        if was_running or cfg.playback.auto_start:
+            player.start()
+
+        flash("Konfiguration importiert", "success")
+        return redirect(url_for("system_settings"))
 
     @app.route("/logs/<string:name>")
     @pam_required
@@ -179,6 +412,28 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         except ValueError:
             abort(404)
         return Response(content, mimetype="text/plain; charset=utf-8")
+
+    @app.route("/logs/<string:name>/download")
+    @pam_required
+    def download_log(name: str):
+        log_sources = available_logs()
+        info = log_sources.get(name)
+        if not info:
+            abort(404)
+        path = pathlib.Path(info["path"])
+        if not path.exists() or not path.is_file():
+            abort(404)
+        try:
+            response = send_file(
+                path,
+                mimetype="text/plain; charset=utf-8",
+                as_attachment=True,
+                download_name=path.name,
+            )
+        except FileNotFoundError:
+            abort(404)
+        response.headers["Cache-Control"] = "no-store, max-age=0"
+        return response
 
     @app.route("/playlist/<int:index>/delete", methods=["POST"])
     @pam_required
@@ -334,7 +589,7 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         playback.image_rotation = rotation % 360
 
         transition = (request.form.get("transition_type") or playback.transition_type or "none").lower()
-        if transition not in {"none", "fade", "slide"}:
+        if transition not in ALLOWED_TRANSITIONS:
             transition = "none"
         playback.transition_type = transition
 
@@ -354,10 +609,24 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
         playback.splitscreen_enabled = splitscreen_enabled
         left_source = request.form.get("splitscreen_left_source")
         right_source = request.form.get("splitscreen_right_source")
+        def _normalize_split_path(raw: Optional[str]) -> str:
+            if not raw:
+                return ""
+            return str(raw).strip().replace("\\", "/")
+
         playback.splitscreen_left_source = left_source or None
-        playback.splitscreen_left_path = (request.form.get("splitscreen_left_path") or "").strip()
+        playback.splitscreen_left_path = _normalize_split_path(
+            request.form.get("splitscreen_left_path")
+        )
         playback.splitscreen_right_source = right_source or None
-        playback.splitscreen_right_path = (request.form.get("splitscreen_right_path") or "").strip()
+        playback.splitscreen_right_path = _normalize_split_path(
+            request.form.get("splitscreen_right_path")
+        )
+        try:
+            ratio_value = int(request.form.get("splitscreen_ratio") or playback.splitscreen_ratio)
+        except ValueError:
+            ratio_value = playback.splitscreen_ratio
+        playback.splitscreen_ratio = max(10, min(90, ratio_value))
 
         cfg.save()
         player.reload()
@@ -416,15 +685,38 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     @pam_required
     def api_state():
         state = get_state()
+        svc_status = system_manager.service_status()
         return jsonify({
             "primary_item": state.primary_item,
             "primary_status": state.primary_status,
             "primary_started_at": state.primary_started_at,
+            "primary_source": state.primary_source,
+            "primary_media_path": state.primary_media_path,
+            "primary_media_type": state.primary_media_type,
+            "primary_preview": state.primary_preview,
+            "primary_preview_token": _preview_token(state.primary_preview),
+            "primary_preview_available": bool(
+                state.primary_preview
+                and state.primary_media_type in {"image", "info"}
+            ),
             "secondary_item": state.secondary_item,
             "secondary_status": state.secondary_status,
             "secondary_started_at": state.secondary_started_at,
+            "secondary_source": state.secondary_source,
+            "secondary_media_path": state.secondary_media_path,
+            "secondary_media_type": state.secondary_media_type,
+            "secondary_preview": state.secondary_preview,
+            "secondary_preview_token": _preview_token(state.secondary_preview),
+            "secondary_preview_available": bool(
+                state.secondary_preview
+                and state.secondary_media_type in {"image", "info"}
+            ),
             "info_screen": state.info_screen,
             "info_manual": state.info_manual,
+            "service_status": svc_status,
+            "service_active": service_active(svc_status),
+            "version": app.config.get("SLIDESHOW_VERSION"),
+            "theme": app.config.get("SLIDESHOW_THEME", cfg.ui.theme),
         })
 
     @app.route("/api/config")
@@ -434,6 +726,141 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             "sources": media_manager.serialize_sources(),
             "playlist": media_manager.serialize_playlist(),
             "network": network_manager.serialize(),
+            "playback": dataclasses.asdict(cfg.playback),
         })
+
+    @app.route("/api/player/<string:action>", methods=["POST"])
+    @pam_required
+    def api_player_action(action: str):
+        try:
+            if action == "start":
+                player.start()
+            elif action == "stop":
+                player.stop()
+            elif action == "reload":
+                player.reload()
+            else:
+                return jsonify({"status": "error", "message": "Unbekannte Aktion"}), 400
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.exception("API-Aktion %s fehlgeschlagen", action)
+            return jsonify({"status": "error", "message": str(exc)}), 500
+        return jsonify({"status": "ok", "action": action})
+
+    @app.route("/api/player/info-screen", methods=["POST"])
+    @pam_required
+    def api_player_info_screen():
+        payload = request.get_json(silent=True) or {}
+        enabled = bool(payload.get("enabled"))
+        player.show_info_screen(enabled)
+        return jsonify({"status": "ok", "enabled": enabled})
+
+    @app.route("/api/playback", methods=["PUT"])
+    @pam_required
+    def api_update_playback():
+        data = request.get_json(silent=True) or {}
+        playback = cfg.playback
+        try:
+            if "image_duration" in data:
+                playback.image_duration = max(1, int(data["image_duration"]))
+            if "image_fit" in data:
+                fit = str(data["image_fit"]).lower()
+                if fit not in {"contain", "stretch", "original"}:
+                    raise ValueError("Ungültiger Bildmodus")
+                playback.image_fit = fit
+            if "image_rotation" in data:
+                playback.image_rotation = int(data["image_rotation"]) % 360
+            if "transition_type" in data:
+                transition = str(data["transition_type"]).lower()
+                if transition not in ALLOWED_TRANSITIONS:
+                    raise ValueError("Unbekannter Übergang")
+                playback.transition_type = transition
+            if "transition_duration" in data:
+                playback.transition_duration = max(0.2, min(10.0, float(data["transition_duration"])))
+            if "display_resolution" in data:
+                playback.display_resolution = str(data["display_resolution"]).strip()
+            if "video_player_args" in data:
+                playback.video_player_args = [str(arg) for arg in data["video_player_args"] if str(arg).strip()]
+            if "image_viewer_args" in data:
+                playback.image_viewer_args = [str(arg) for arg in data["image_viewer_args"] if str(arg).strip()]
+            if "splitscreen_enabled" in data:
+                playback.splitscreen_enabled = bool(data["splitscreen_enabled"])
+            if "splitscreen_left_source" in data:
+                playback.splitscreen_left_source = data["splitscreen_left_source"] or None
+            if "splitscreen_left_path" in data:
+                playback.splitscreen_left_path = str(data["splitscreen_left_path"]).strip()
+            if "splitscreen_right_source" in data:
+                playback.splitscreen_right_source = data["splitscreen_right_source"] or None
+            if "splitscreen_right_path" in data:
+                playback.splitscreen_right_path = str(data["splitscreen_right_path"]).strip()
+            if "splitscreen_ratio" in data:
+                try:
+                    ratio_value = int(data["splitscreen_ratio"])
+                except (TypeError, ValueError):
+                    raise ValueError("Ungültiges Splitscreen-Verhältnis")
+                playback.splitscreen_ratio = max(10, min(90, ratio_value))
+        except (TypeError, ValueError) as exc:
+            return jsonify({"status": "error", "message": str(exc)}), 400
+
+        cfg.save()
+        player.reload()
+        return jsonify({"status": "ok", "playback": dataclasses.asdict(playback)})
+
+    @app.route("/api/sources", methods=["GET", "POST"])
+    @pam_required
+    def api_sources():
+        if request.method == "GET":
+            return jsonify({"sources": media_manager.serialize_sources()})
+
+        payload = request.get_json(silent=True) or {}
+        try:
+            source = media_manager.add_smb_source(
+                name=payload.get("name", "").strip(),
+                server=payload.get("server"),
+                share=payload.get("share"),
+                username=payload.get("username"),
+                password=payload.get("password"),
+                domain=payload.get("domain"),
+                subpath=payload.get("subpath"),
+                smb_path=payload.get("smb_path"),
+                auto_scan=bool(payload.get("auto_scan", True)),
+            )
+        except Exception as exc:
+            LOGGER.exception("Konnte Quelle nicht anlegen")
+            return jsonify({"status": "error", "message": str(exc)}), 400
+        player.reload()
+        return jsonify({"status": "ok", "source": dataclasses.asdict(source)})
+
+    @app.route("/api/sources/<path:name>", methods=["PUT", "DELETE"])
+    @pam_required
+    def api_source_detail(name: str):
+        if request.method == "DELETE":
+            try:
+                media_manager.remove_source(name)
+            except Exception as exc:
+                return jsonify({"status": "error", "message": str(exc)}), 400
+            player.reload()
+            return jsonify({"status": "ok"})
+
+        payload = request.get_json(silent=True) or {}
+        try:
+            password_value = payload.get("password")
+            password = password_value if password_value is not None else None
+            source = media_manager.update_source(
+                name,
+                new_name=payload.get("name"),
+                smb_path=payload.get("smb_path"),
+                server=payload.get("server"),
+                share=payload.get("share"),
+                username=payload.get("username"),
+                password=password,
+                domain=payload.get("domain"),
+                subpath=payload.get("subpath"),
+                auto_scan=payload.get("auto_scan"),
+            )
+        except Exception as exc:
+            LOGGER.exception("Konnte Quelle nicht aktualisieren")
+            return jsonify({"status": "error", "message": str(exc)}), 400
+        player.reload()
+        return jsonify({"status": "ok", "source": dataclasses.asdict(source)})
 
     return app

--- a/slideshow/media.py
+++ b/slideshow/media.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import io
 import mimetypes
 import os
 import pathlib
@@ -12,12 +13,16 @@ import subprocess
 from dataclasses import asdict
 from typing import List, Optional
 
+from PIL import Image
+
 from .config import (
     AppConfig,
+    CACHE_DIR,
     DATA_DIR,
     MediaSource,
     PlaylistItem,
     delete_secret,
+    ensure_cache_dir,
     load_secret,
     save_secret,
 )
@@ -26,6 +31,8 @@ LOGGER = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".bmp"}
 VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".webm"}
+IGNORED_EXTENSIONS = {".db", ".ini", ".tmp", ".ds_store"}
+CACHEABLE_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_MOUNT_HELPER = BASE_DIR / "scripts" / "mount_smb.sh"
@@ -86,6 +93,7 @@ class MediaManager:
             MOUNT_ROOT.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             LOGGER.warning("Konnte Mount-Verzeichnis %s nicht anlegen: %s", MOUNT_ROOT, exc)
+        ensure_cache_dir()
         self._migrate_mount_points()
         self._ensure_local_directories()
 
@@ -282,6 +290,151 @@ class MediaManager:
         delete_secret(f"smb:{name}")
         self.config.save()
 
+    def update_source(
+        self,
+        name: str,
+        *,
+        new_name: Optional[str] = None,
+        smb_path: Optional[str] = None,
+        server: Optional[str] = None,
+        share: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        domain: Optional[str] = None,
+        subpath: Optional[str] = None,
+        auto_scan: Optional[bool] = None,
+    ) -> MediaSource:
+        source = self.config.get_source(name)
+        if not source:
+            raise ValueError(f"Unbekannte Quelle: {name}")
+        if source.type != "smb":
+            raise ValueError("Nur SMB-Quellen können bearbeitet werden")
+
+        target_name = new_name.strip() if new_name else name
+        if not target_name:
+            raise ValueError("Der Name darf nicht leer sein")
+        if target_name != name and self.config.get_source(target_name):
+            raise ValueError(f"Eine Quelle mit dem Namen {target_name} existiert bereits")
+
+        parsed_subpath = None
+        if smb_path:
+            server, share, parsed_subpath = parse_smb_location(smb_path)
+
+        normalized_subpath = _normalize_subpath(subpath or parsed_subpath or source.subpath)
+
+        if target_name != name:
+            for item in self.config.playlist:
+                if item.source == name:
+                    item.source = target_name
+            playback = self.config.playback
+            if playback.splitscreen_left_source == name:
+                playback.splitscreen_left_source = target_name
+            if playback.splitscreen_right_source == name:
+                playback.splitscreen_right_source = target_name
+            secret = load_secret(f"smb:{name}")
+            if secret:
+                save_secret(f"smb:{target_name}", secret)
+            delete_secret(f"smb:{name}")
+            for idx, existing in enumerate(self.config.media_sources):
+                if existing.name == name:
+                    self.config.media_sources[idx].name = target_name
+            source = self.config.get_source(target_name)
+            if not source:
+                raise RuntimeError("Aktualisierte Quelle nicht gefunden")
+            name = target_name
+
+        options = dict(source.options)
+        if server:
+            options["server"] = server
+        if share:
+            options["share"] = share
+
+        if username is not None:
+            username = username or None
+            if username:
+                options["username"] = username
+            else:
+                options.pop("username", None)
+        if domain is not None:
+            domain = domain or None
+            if domain:
+                options["domain"] = domain
+            else:
+                options.pop("domain", None)
+
+        if password is not None:
+            if password:
+                save_secret(f"smb:{name}", password)
+            else:
+                delete_secret(f"smb:{name}")
+
+        source.options = options
+        source.subpath = normalized_subpath
+        if auto_scan is not None:
+            source.auto_scan = bool(auto_scan)
+
+        self.config.save()
+        return source
+
+    def _cache_path(self, source: MediaSource, relative_path: str) -> pathlib.Path:
+        return (CACHE_DIR / source.name) / pathlib.Path(relative_path)
+
+    def _should_cache(self, path: pathlib.Path) -> bool:
+        return path.suffix.lower() in CACHEABLE_EXTENSIONS
+
+    def _ensure_cached(self, source: MediaSource, path: pathlib.Path, relative_path: str) -> pathlib.Path:
+        if source.type == "local" or not self._should_cache(path):
+            return path
+        cache_target = self._cache_path(source, relative_path)
+        try:
+            cache_target.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            LOGGER.debug("Konnte Cache-Verzeichnis %s nicht erstellen", cache_target.parent)
+            return path
+        try:
+            if not cache_target.exists() or path.stat().st_mtime > cache_target.stat().st_mtime:
+                shutil.copy2(path, cache_target)
+        except FileNotFoundError:
+            if cache_target.exists():
+                return cache_target
+        except OSError as exc:
+            LOGGER.debug("Konnte %s nicht in den Cache kopieren: %s", path, exc)
+            return path
+        return cache_target if cache_target.exists() else path
+
+    def resolve_media_path(self, source_name: str, relative_path: str) -> pathlib.Path:
+        source = self.config.get_source(source_name)
+        if not source:
+            raise ValueError(f"Unbekannte Quelle: {source_name}")
+        try:
+            self.mount_source(source)
+        except Exception as exc:
+            LOGGER.debug("Mount für %s fehlgeschlagen, nutze ggf. Cache: %s", source_name, exc)
+        base = pathlib.Path(source.path).resolve()
+        target = (base / pathlib.Path(relative_path)).resolve()
+        if base not in target.parents and target != base:
+            raise PermissionError("Pfad liegt außerhalb der Quelle")
+        if target.exists() and target.is_file():
+            return self._ensure_cached(source, target, relative_path)
+        cached = self._cache_path(source, relative_path)
+        if cached.exists() and cached.is_file():
+            return cached
+        raise FileNotFoundError(f"Datei {target} nicht gefunden")
+
+    def generate_preview(self, source_name: str, relative_path: str, size: tuple[int, int] = (240, 135)) -> tuple[bytes, str]:
+        path = self.resolve_media_path(source_name, relative_path)
+        if path.suffix.lower() not in IMAGE_EXTENSIONS:
+            raise TypeError("Nur Bilder werden unterstützt")
+        try:
+            with Image.open(path) as img:  # type: ignore[arg-type]
+                img = img.convert("RGB")
+                img.thumbnail(size, Image.LANCZOS)
+                output = io.BytesIO()
+                img.save(output, format="JPEG", quality=85)
+        except OSError as exc:
+            raise ValueError(f"Konnte Vorschau nicht erzeugen: {exc}") from exc
+        return output.getvalue(), "image/jpeg"
+
     def mount_source(self, source: MediaSource) -> None:
         if source.type != "smb":
             return
@@ -341,6 +494,10 @@ class MediaManager:
         return self.config.playlist
 
     def add_to_playlist(self, item: PlaylistItem) -> None:
+        detected = self.detect_item_type(pathlib.Path(item.path).name)
+        if not detected:
+            raise ValueError(f"Datei {item.path} wird nicht unterstützt")
+        item.type = detected
         self.config.playlist.append(item)
         self.config.save()
 
@@ -349,8 +506,10 @@ class MediaManager:
             del self.config.playlist[index]
             self.config.save()
 
-    def detect_item_type(self, path: str) -> str:
+    def detect_item_type(self, path: str) -> Optional[str]:
         ext = pathlib.Path(path).suffix.lower()
+        if ext in IGNORED_EXTENSIONS:
+            return None
         if ext in IMAGE_EXTENSIONS:
             return "image"
         if ext in VIDEO_EXTENSIONS:
@@ -361,7 +520,7 @@ class MediaManager:
                 return "image"
             if mime.startswith("video"):
                 return "video"
-        return "image"
+        return None
 
     def scan_directory(self, source: MediaSource, base_path: Optional[str] = None) -> List[PlaylistItem]:
         items: List[PlaylistItem] = []
@@ -374,10 +533,33 @@ class MediaManager:
         if not base.exists():
             LOGGER.warning("Verzeichnis %s existiert nicht", base)
             return []
-        for file in sorted(base.rglob("*")):
+        if base.is_file():
+            item_type = self.detect_item_type(base.name)
+            if not item_type:
+                return []
+            try:
+                relative = base.relative_to(source_root)
+            except ValueError:
+                relative = pathlib.Path(base.name)
+            items.append(
+                PlaylistItem(
+                    source=source.name,
+                    path=str(relative),
+                    type=item_type,
+                )
+            )
+            return items
+        try:
+            iterator = base.rglob("*")
+        except NotADirectoryError:
+            LOGGER.warning("Pfad %s konnte nicht durchsucht werden", base)
+            return items
+        for file in sorted(iterator):
             if file.is_dir():
                 continue
             item_type = self.detect_item_type(file.name)
+            if not item_type:
+                continue
             try:
                 relative = file.relative_to(source_root)
             except ValueError:

--- a/slideshow/mpv_controller.py
+++ b/slideshow/mpv_controller.py
@@ -1,0 +1,256 @@
+"""Hilfsmodul zur Steuerung einer dauerhaften mpv-Instanz."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from typing import Iterable, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MpvController:
+    """Kapselt die Kommunikation mit einer persistenten mpv-Instanz."""
+
+    def __init__(
+        self,
+        *,
+        geometry: Optional[str] = None,
+        extra_args: Optional[Iterable[str]] = None,
+        binary: str = "mpv",
+    ) -> None:
+        self.geometry = geometry
+        self.binary = binary
+        self._extra_args = list(extra_args or [])
+        self._process: Optional[subprocess.Popen[bytes]] = None
+        self._socket_dir: Optional[pathlib.Path] = None
+        self._socket_path: Optional[pathlib.Path] = None
+        self._lock = threading.Lock()
+
+    # Lebenszyklus -----------------------------------------------------
+    def start(self) -> bool:
+        """Startet mpv, sofern noch nicht aktiv."""
+        with self._lock:
+            if self._process and self._process.poll() is None:
+                return True
+            self._cleanup_socket()
+            try:
+                self._socket_dir = pathlib.Path(
+                    tempfile.mkdtemp(prefix="slideshow-mpv-")
+                )
+                self._socket_path = self._socket_dir / "socket"
+            except OSError as exc:
+                LOGGER.error("Konnte IPC-Socket nicht erstellen: %s", exc)
+                return False
+
+            cmd = [
+                self.binary,
+                "--no-terminal",
+                "--quiet",
+                "--idle=yes",
+                "--force-window=yes",
+                "--keep-open=yes",
+                f"--input-ipc-server={self._socket_path}",
+            ]
+            if self.geometry:
+                cmd.append(f"--geometry={self.geometry}")
+                cmd.append("--no-border")
+                cmd.append("--keepaspect-window=no")
+            else:
+                cmd.append("--fullscreen")
+            cmd.extend(self._filtered_args())
+            try:
+                self._process = subprocess.Popen(
+                    cmd,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    close_fds=True,
+                )
+            except (FileNotFoundError, OSError) as exc:
+                LOGGER.error("Konnte mpv nicht starten: %s", exc)
+                self._process = None
+                self._cleanup_socket()
+                return False
+
+        # Warten bis der Socket bereitsteht
+        return self._wait_for_socket()
+
+    def ensure_running(self) -> bool:
+        if self._process and self._process.poll() is None:
+            return True
+        return self.start()
+
+    def stop(self) -> None:
+        with self._lock:
+            if not self._process:
+                self._cleanup_socket()
+                return
+            if self._process.poll() is None:
+                try:
+                    self._command_no_lock(["quit"])
+                except Exception:
+                    # Ignorieren und hart stoppen
+                    pass
+                try:
+                    self._process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._process.terminate()
+                    try:
+                        self._process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        self._process.kill()
+                        self._process.wait(timeout=3)
+            self._process = None
+            self._cleanup_socket()
+
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    # Befehle ----------------------------------------------------------
+    def load_file(self, path: pathlib.Path) -> bool:
+        if not self.ensure_running():
+            return False
+        response = self._command(["loadfile", str(path), "replace"])
+        if isinstance(response, dict) and response.get("error") == "success":
+            # Nach einem erfolgreichen Load sicherstellen, dass die Instanz
+            # nicht im Pausenmodus verharrt.
+            self._command(["set_property", "pause", False])
+            return True
+        return False
+
+    def stop_playback(self) -> None:
+        self._command(["stop"])
+
+    def set_property(self, name: str, value: object) -> None:
+        self._command(["set_property", name, value])
+
+    def is_idle(self) -> bool:
+        response = self._command(["get_property", "idle-active"])
+        if isinstance(response, dict):
+            return response.get("error") == "success" and bool(response.get("data"))
+        return False
+
+    def wait_until_idle(self, should_abort) -> bool:
+        """Wartet bis mpv in den Idle-Zustand zurückkehrt.
+
+        :param should_abort: Callable ohne Argumente, das bei Abbruch True liefert.
+        :returns: True falls die Wiedergabe normal beendet wurde, sonst False.
+        """
+        while True:
+            if should_abort():
+                return False
+            if not self.is_running():
+                return True
+            if self.is_idle():
+                return True
+            if self._get_property_bool("eof-reached"):
+                # EOF erreicht – Wiedergabe stoppen, um den Zustand zurückzusetzen.
+                self.stop_playback()
+                return True
+            if self._get_property_bool("pause"):
+                # Bei aktivem keep-open signalisiert pause=True einen Abschluss.
+                return True
+            time.sleep(0.2)
+
+    # Interne Helfer ---------------------------------------------------
+    def _command(self, payload) -> Optional[dict]:
+        with self._lock:
+            return self._command_no_lock(payload)
+
+    def _filtered_args(self) -> list[str]:
+        if not self._extra_args:
+            return []
+        if not self.geometry:
+            return list(self._extra_args)
+
+        blocked_flags = {"--fullscreen", "--fs"}
+        blocked_single_value = {"--geometry", "--screen", "--autofit", "--autofit-larger"}
+        blocked_prefixes = ("--geometry=", "--fs=", "--fullscreen=", "--screen=", "--autofit=", "--autofit-larger=")
+
+        filtered: list[str] = []
+        skip_next = False
+        for arg in self._extra_args:
+            if skip_next:
+                skip_next = False
+                continue
+            lowered = arg.lower()
+            if lowered in blocked_flags:
+                continue
+            if lowered in blocked_single_value:
+                skip_next = True
+                continue
+            if any(lowered.startswith(prefix) for prefix in blocked_prefixes):
+                continue
+            filtered.append(arg)
+        return filtered
+
+    def _command_no_lock(self, payload) -> Optional[dict]:
+        if not self._socket_path:
+            return None
+        if not self._socket_path.exists():
+            return None
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as conn:
+                conn.connect(os.fspath(self._socket_path))
+                message = json.dumps({"command": payload}).encode("utf-8") + b"\n"
+                conn.sendall(message)
+                data = b""
+                while not data.endswith(b"\n"):
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+        except OSError as exc:
+            LOGGER.debug("Fehler bei mpv-Kommunikation: %s", exc)
+            return None
+        if not data:
+            return None
+        try:
+            return json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError:
+            LOGGER.debug("Ungültige mpv-Antwort: %s", data)
+            return None
+
+    def _get_property_bool(self, name: str) -> bool:
+        response = self._command(["get_property", name])
+        if isinstance(response, dict) and response.get("error") == "success":
+            return bool(response.get("data"))
+        return False
+
+    def _wait_for_socket(self) -> bool:
+        timeout = time.time() + 5
+        while time.time() < timeout:
+            if self._socket_path and self._socket_path.exists():
+                return True
+            if self._process and self._process.poll() is not None:
+                return False
+            time.sleep(0.1)
+        LOGGER.error("mpv-IPC-Socket wurde nicht erstellt")
+        return False
+
+    def _cleanup_socket(self) -> None:
+        if self._socket_path and self._socket_path.exists():
+            try:
+                self._socket_path.unlink()
+            except OSError:
+                pass
+        if self._socket_dir and self._socket_dir.exists():
+            try:
+                self._socket_dir.rmdir()
+            except OSError:
+                # Verzeichnis evtl. nicht leer
+                try:
+                    for child in self._socket_dir.iterdir():
+                        child.unlink()
+                    self._socket_dir.rmdir()
+                except OSError:
+                    pass
+        self._socket_path = None
+        self._socket_dir = None

--- a/slideshow/state.py
+++ b/slideshow/state.py
@@ -18,9 +18,17 @@ class PlaybackState:
     primary_item: Optional[str]
     primary_started_at: Optional[float]
     primary_status: str
+    primary_source: Optional[str]
+    primary_media_path: Optional[str]
+    primary_media_type: Optional[str]
+    primary_preview: Optional[str]
     secondary_item: Optional[str]
     secondary_started_at: Optional[float]
     secondary_status: str
+    secondary_source: Optional[str]
+    secondary_media_path: Optional[str]
+    secondary_media_type: Optional[str]
+    secondary_preview: Optional[str]
     info_screen: bool
     info_manual: bool
 
@@ -29,9 +37,17 @@ _state = PlaybackState(
     primary_item=None,
     primary_started_at=None,
     primary_status="stopped",
+    primary_source=None,
+    primary_media_path=None,
+    primary_media_type=None,
+    primary_preview=None,
     secondary_item=None,
     secondary_started_at=None,
     secondary_status="stopped",
+    secondary_source=None,
+    secondary_media_path=None,
+    secondary_media_type=None,
+    secondary_preview=None,
     info_screen=False,
     info_manual=False,
 )
@@ -48,9 +64,17 @@ def load_state() -> PlaybackState:
                 primary_item=data.get("primary_item", data.get("current_item")),
                 primary_started_at=data.get("primary_started_at", data.get("started_at")),
                 primary_status=data.get("primary_status", data.get("status", "stopped")),
+                primary_source=data.get("primary_source"),
+                primary_media_path=data.get("primary_media_path"),
+                primary_media_type=data.get("primary_media_type"),
+                primary_preview=data.get("primary_preview"),
                 secondary_item=data.get("secondary_item"),
                 secondary_started_at=data.get("secondary_started_at"),
                 secondary_status=data.get("secondary_status", "stopped"),
+                secondary_source=data.get("secondary_source"),
+                secondary_media_path=data.get("secondary_media_path"),
+                secondary_media_type=data.get("secondary_media_type"),
+                secondary_preview=data.get("secondary_preview"),
                 info_screen=data.get("info_screen", False),
                 info_manual=data.get("info_manual", False),
             )
@@ -71,8 +95,10 @@ def set_state(
     info_screen: bool = False,
     info_manual: bool = False,
     side: str = "primary",
-    secondary_item: Optional[str] = None,
-    secondary_status: Optional[str] = None,
+    source: Optional[str] = None,
+    media_path: Optional[str] = None,
+    media_type: Optional[str] = None,
+    preview_path: Optional[str] = None,
 ) -> PlaybackState:
     """Aktualisiert den Wiedergabestatus."""
 
@@ -83,16 +109,38 @@ def set_state(
             state.secondary_item = current_item
             state.secondary_status = status
             state.secondary_started_at = now if current_item else None
+            if current_item is None:
+                state.secondary_source = None
+                state.secondary_media_path = None
+                state.secondary_media_type = None
+                state.secondary_preview = None
+            else:
+                if source is not None:
+                    state.secondary_source = source
+                if media_path is not None:
+                    state.secondary_media_path = media_path
+                if media_type is not None:
+                    state.secondary_media_type = media_type
+                if preview_path is not None:
+                    state.secondary_preview = preview_path
         else:
             state.primary_item = current_item
             state.primary_status = status
             state.primary_started_at = now if current_item else None
-            if secondary_item is not None or secondary_status is not None:
-                state.secondary_item = secondary_item
-                state.secondary_status = secondary_status or (
-                    "stopped" if secondary_item is None else status
-                )
-                state.secondary_started_at = now if secondary_item else None
+            if current_item is None:
+                state.primary_source = None
+                state.primary_media_path = None
+                state.primary_media_type = None
+                state.primary_preview = None
+            else:
+                if source is not None:
+                    state.primary_source = source
+                if media_path is not None:
+                    state.primary_media_path = media_path
+                if media_type is not None:
+                    state.primary_media_type = media_type
+                if preview_path is not None:
+                    state.primary_preview = preview_path
         state.info_screen = info_screen
         state.info_manual = info_manual
         save_state(state)

--- a/slideshow/static/style.css
+++ b/slideshow/static/style.css
@@ -1,10 +1,111 @@
 :root {
-  color-scheme: dark light;
+  color-scheme: light dark;
   font-family: "Segoe UI", Roboto, sans-serif;
-  --primary: #2b6cb0;
   --bg: #0f172a;
   --fg: #f8fafc;
-  --card: rgba(255, 255, 255, 0.08);
+  --muted: #94a3b8;
+  --surface: rgba(255, 255, 255, 0.08);
+  --surface-strong: rgba(15, 23, 42, 0.45);
+  --surface-alt: rgba(15, 23, 42, 0.6);
+  --border: rgba(148, 163, 184, 0.3);
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+  --primary: #38bdf8;
+  --primary-contrast: #0f172a;
+  --status-ok: #34d399;
+  --status-down: #f87171;
+  --status-info: #38bdf8;
+  --status-ok-bg: rgba(52, 211, 153, 0.18);
+  --status-ok-border: rgba(52, 211, 153, 0.4);
+  --status-down-bg: rgba(248, 113, 113, 0.18);
+  --status-down-border: rgba(248, 113, 113, 0.4);
+  --status-info-bg: rgba(56, 189, 248, 0.2);
+  --status-info-border: rgba(56, 189, 248, 0.45);
+  --status-neutral-bg: rgba(148, 163, 184, 0.2);
+  --status-neutral-border: rgba(148, 163, 184, 0.35);
+  --flash-success: rgba(52, 211, 153, 0.18);
+  --flash-danger: rgba(248, 113, 113, 0.18);
+  --flash-info: rgba(56, 189, 248, 0.2);
+}
+
+.theme-light {
+  --bg: #f5f7fa;
+  --fg: #0f172a;
+  --muted: #475569;
+  --surface: #ffffff;
+  --surface-strong: #e2e8f0;
+  --surface-alt: #eef2ff;
+  --border: rgba(148, 163, 184, 0.35);
+  --shadow: 0 12px 36px rgba(15, 23, 42, 0.12);
+  --primary: #2563eb;
+  --primary-contrast: #f8fafc;
+  --status-ok: #16a34a;
+  --status-down: #dc2626;
+  --status-info: #0ea5e9;
+  --status-ok-bg: rgba(22, 163, 74, 0.16);
+  --status-ok-border: rgba(22, 163, 74, 0.4);
+  --status-down-bg: rgba(220, 38, 38, 0.16);
+  --status-down-border: rgba(220, 38, 38, 0.4);
+  --status-info-bg: rgba(14, 165, 233, 0.18);
+  --status-info-border: rgba(14, 165, 233, 0.45);
+  --status-neutral-bg: rgba(148, 163, 184, 0.18);
+  --status-neutral-border: rgba(148, 163, 184, 0.35);
+  --flash-success: rgba(22, 163, 74, 0.16);
+  --flash-danger: rgba(220, 38, 38, 0.16);
+  --flash-info: rgba(14, 165, 233, 0.18);
+}
+
+.theme-mid {
+  --bg: #0f172a;
+  --fg: #f8fafc;
+  --muted: #94a3b8;
+  --surface: rgba(255, 255, 255, 0.08);
+  --surface-strong: rgba(15, 23, 42, 0.45);
+  --surface-alt: rgba(15, 23, 42, 0.6);
+  --border: rgba(148, 163, 184, 0.3);
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+  --primary: #38bdf8;
+  --primary-contrast: #0f172a;
+  --status-ok: #34d399;
+  --status-down: #f87171;
+  --status-info: #38bdf8;
+  --status-ok-bg: rgba(52, 211, 153, 0.18);
+  --status-ok-border: rgba(52, 211, 153, 0.4);
+  --status-down-bg: rgba(248, 113, 113, 0.18);
+  --status-down-border: rgba(248, 113, 113, 0.4);
+  --status-info-bg: rgba(56, 189, 248, 0.2);
+  --status-info-border: rgba(56, 189, 248, 0.45);
+  --status-neutral-bg: rgba(148, 163, 184, 0.2);
+  --status-neutral-border: rgba(148, 163, 184, 0.35);
+  --flash-success: rgba(52, 211, 153, 0.18);
+  --flash-danger: rgba(248, 113, 113, 0.18);
+  --flash-info: rgba(56, 189, 248, 0.2);
+}
+
+.theme-dark {
+  --bg: #05070e;
+  --fg: #e2e8f0;
+  --muted: #94a3b8;
+  --surface: rgba(17, 24, 39, 0.85);
+  --surface-strong: rgba(30, 41, 59, 0.7);
+  --surface-alt: rgba(30, 41, 59, 0.6);
+  --border: rgba(148, 163, 184, 0.25);
+  --shadow: 0 14px 40px rgba(2, 6, 23, 0.6);
+  --primary: #8b5cf6;
+  --primary-contrast: #0f172a;
+  --status-ok: #4ade80;
+  --status-down: #fb7185;
+  --status-info: #38bdf8;
+  --status-ok-bg: rgba(74, 222, 128, 0.22);
+  --status-ok-border: rgba(74, 222, 128, 0.45);
+  --status-down-bg: rgba(251, 113, 133, 0.22);
+  --status-down-border: rgba(251, 113, 133, 0.45);
+  --status-info-bg: rgba(56, 189, 248, 0.22);
+  --status-info-border: rgba(56, 189, 248, 0.5);
+  --status-neutral-bg: rgba(148, 163, 184, 0.25);
+  --status-neutral-border: rgba(148, 163, 184, 0.4);
+  --flash-success: rgba(74, 222, 128, 0.2);
+  --flash-danger: rgba(251, 113, 133, 0.2);
+  --flash-info: rgba(56, 189, 248, 0.22);
 }
 
 body {
@@ -14,17 +115,22 @@ body {
   min-height: 100vh;
 }
 
+a {
+  color: inherit;
+}
+
 .topbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background: rgba(15, 23, 42, 0.8);
+  background: var(--surface-alt);
   backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
   gap: 1rem;
   flex-wrap: wrap;
+  box-shadow: var(--shadow);
 }
 
 .topbar .main-nav {
@@ -38,18 +144,18 @@ body {
   font-weight: 600;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .topbar .main-nav a.active,
 .topbar .main-nav a:hover {
-  background: rgba(59, 130, 246, 0.25);
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .topbar .version {
   margin-left: auto;
   font-size: 0.9rem;
-  opacity: 0.8;
+  opacity: 0.75;
 }
 
 .content {
@@ -71,10 +177,10 @@ body {
 }
 
 article {
-  background: var(--card);
+  background: var(--surface);
   padding: 1.5rem;
   border-radius: 1rem;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.3);
+  box-shadow: var(--shadow);
 }
 
 article h2 {
@@ -82,7 +188,7 @@ article h2 {
 }
 
 .status-block {
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--surface-strong);
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
   margin-bottom: 0.75rem;
@@ -91,6 +197,49 @@ article h2 {
 .status-block h3 {
   margin: 0 0 0.5rem 0;
   font-size: 1rem;
+}
+
+.status-block p strong {
+  display: inline-block;
+  min-width: 6rem;
+}
+
+.status-preview {
+  margin-top: 0.75rem;
+}
+
+.status-preview__frame {
+  position: relative;
+  width: 100%;
+  max-width: 340px;
+  aspect-ratio: 16 / 9;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.status-preview__frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.status-preview__placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 0.75rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: linear-gradient(135deg, transparent, rgba(0, 0, 0, 0.15));
+}
+
+.status-preview__placeholder[hidden] {
+  display: none;
 }
 
 table {
@@ -105,27 +254,34 @@ table {
 
 table th,
 table td {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--border);
   padding: 0.5rem;
   text-align: left;
 }
 
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.6rem;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
   color: var(--fg);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--muted);
+  opacity: 0.85;
 }
 
 button {
   background: var(--primary);
   border: none;
   cursor: pointer;
-  color: white;
+  color: var(--primary-contrast);
   transition: filter 0.2s ease;
 }
 
@@ -135,7 +291,7 @@ button.danger {
 
 button:hover,
 .button-link:hover {
-  filter: brightness(1.1);
+  filter: brightness(1.08);
 }
 
 form {
@@ -153,6 +309,60 @@ form {
   margin: 0;
 }
 
+.status-flags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--fg);
+}
+
+.status-indicator::before {
+  content: "";
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+
+.status-indicator--ok {
+  border-color: var(--status-ok-border);
+  background: var(--status-ok-bg);
+  color: var(--status-ok);
+}
+
+.status-indicator--down {
+  border-color: var(--status-down-border);
+  background: var(--status-down-bg);
+  color: var(--status-down);
+}
+
+.status-indicator--info {
+  border-color: var(--status-info-border);
+  background: var(--status-info-bg);
+  color: var(--status-info);
+}
+
+.status-indicator--neutral {
+  border-color: var(--status-neutral-border);
+  background: var(--status-neutral-bg);
+  color: var(--muted);
+}
+
 .logs {
   display: flex;
   flex-direction: column;
@@ -167,7 +377,7 @@ form {
 }
 
 .logs pre {
-  background: rgba(15, 23, 42, 0.7);
+  background: var(--surface-alt);
   border-radius: 0.75rem;
   padding: 1rem;
   min-height: 200px;
@@ -176,6 +386,7 @@ form {
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 0.85rem;
   white-space: pre-wrap;
+  border: 1px solid var(--border);
 }
 
 .table-actions {
@@ -192,6 +403,7 @@ form {
 .inline-form label {
   display: flex;
   flex-direction: column;
+  gap: 0.35rem;
   margin-bottom: 0.5rem;
 }
 
@@ -209,15 +421,23 @@ form {
 }
 
 .grid-form fieldset {
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border);
   border-radius: 0.75rem;
   padding: 1rem;
   min-width: 0;
+  background: var(--surface);
 }
 
 .grid-form fieldset legend {
   padding: 0 0.5rem;
   font-weight: 600;
+}
+
+.grid-form > button,
+.grid-form > .button-link {
+  justify-self: start;
+  width: auto;
+  max-width: 280px;
 }
 
 .split-grid {
@@ -226,8 +446,28 @@ form {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
+.split-grid[hidden] {
+  display: none;
+}
+
 .split-grid h4 {
   margin: 0 0 0.5rem 0;
+}
+
+.split-ratio {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.split-ratio__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.split-ratio[hidden] {
+  display: none;
 }
 
 .checkbox {
@@ -242,7 +482,7 @@ form {
 }
 
 .muted {
-  color: rgba(248, 250, 252, 0.75);
+  color: var(--muted);
   font-size: 0.95rem;
 }
 
@@ -252,11 +492,32 @@ form {
   justify-content: center;
   padding: 0.6rem 1rem;
   border-radius: 0.75rem;
-  background: rgba(59, 130, 246, 0.35);
-  color: var(--fg);
+  background: var(--primary);
+  color: var(--primary-contrast);
   text-decoration: none;
   font-weight: 600;
   margin-top: 0.5rem;
+  border: none;
+  transition: filter 0.2s ease;
+}
+
+.button-link.is-disabled {
+  opacity: 0.55;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
+.table-actions .button-link {
+  margin-top: 0;
+}
+
+.playlist-preview {
+  width: 88px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
 }
 
 .hint-list {
@@ -275,35 +536,37 @@ form {
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
   margin-bottom: 0.5rem;
+  color: var(--fg);
 }
 
 .flash.success {
-  background: rgba(56, 161, 105, 0.2);
+  background: var(--flash-success);
 }
 
 .flash.danger {
-  background: rgba(229, 62, 62, 0.2);
+  background: var(--flash-danger);
 }
 
 .flash.info {
-  background: rgba(66, 153, 225, 0.2);
+  background: var(--flash-info);
 }
 
 .login-page {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #1e293b, #0f172a);
-  height: 100vh;
+  background: linear-gradient(135deg, var(--surface-alt), var(--bg));
+  min-height: 100vh;
 }
 
 .login-form {
-  background: rgba(15, 23, 42, 0.8);
+  background: var(--surface);
   padding: 2rem;
   border-radius: 1rem;
   width: min(320px, 90vw);
   display: grid;
-  gap: 0.5rem;
+  gap: 0.6rem;
+  box-shadow: var(--shadow);
 }
 
 .login-form h1 {
@@ -320,4 +583,19 @@ form {
   margin-top: 1rem;
   font-size: 0.85rem;
   opacity: 0.75;
+}
+
+.theme-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.theme-form button {
+  align-self: center;
+}
+
+.logs .button-link {
+  margin-top: 0;
 }

--- a/slideshow/templates/dashboard.html
+++ b/slideshow/templates/dashboard.html
@@ -4,21 +4,43 @@
 <section class="grid overview-grid">
   <article>
     <h2>Aktueller Status</h2>
+    <div class="status-flags">
+      <span data-status="service" class="status-indicator {% if service_active %}status-indicator--ok{% else %}status-indicator--down{% endif %}">
+        {% if service_active %}Dienst läuft{% else %}Dienst ist inaktiv{% endif %}
+      </span>
+      <span data-status="info" class="status-indicator {% if state and state.info_screen %}status-indicator--info{% else %}status-indicator--neutral{% endif %}">
+        {% if state and state.info_screen %}Infobildschirm aktiv{% else %}Infobildschirm aus{% endif %}
+      </span>
+    </div>
     <div class="status-block">
       <h3>Primäre Anzeige</h3>
-      <p><strong>Datei:</strong> {{ state.primary_item or '–' }}</p>
-      <p><strong>Status:</strong> {{ state.primary_status or 'unbekannt' }}</p>
-      <p><strong>Gestartet:</strong> {% if state.primary_started_at %}{{ state.primary_started_at | datetimeformat }}{% else %}–{% endif %}</p>
+      <p><strong>Quelle:</strong> <span data-state="primary-source">{{ state.primary_source or '–' }}</span></p>
+      <p><strong>Datei:</strong> <span data-state="primary-item">{{ state.primary_media_path or state.primary_item or '–' }}</span></p>
+      <p><strong>Status:</strong> <span data-state="primary-status">{{ state.primary_status or 'unbekannt' }}</span></p>
+      <p><strong>Gestartet:</strong> <span data-state="primary-started">{% if state.primary_started_at %}{{ state.primary_started_at | datetimeformat }}{% else %}–{% endif %}</span></p>
+      <div class="status-preview" data-preview="primary">
+        <div class="status-preview__frame">
+          <img data-preview-image="primary" src="{{ url_for('state_preview', side='primary') }}" alt="Vorschau primäre Anzeige" hidden />
+          <span data-preview-placeholder="primary" class="status-preview__placeholder">Keine Vorschau verfügbar</span>
+        </div>
+      </div>
     </div>
     {% if config.playback.splitscreen_enabled %}
-    <div class="status-block">
+    <div class="status-block" data-secondary-status>
       <h3>Splitscreen rechts</h3>
-      <p><strong>Datei:</strong> {{ state.secondary_item or '–' }}</p>
-      <p><strong>Status:</strong> {{ state.secondary_status or 'unbekannt' }}</p>
-      <p><strong>Gestartet:</strong> {% if state.secondary_started_at %}{{ state.secondary_started_at | datetimeformat }}{% else %}–{% endif %}</p>
+      <p><strong>Quelle:</strong> <span data-state="secondary-source">{{ state.secondary_source or '–' }}</span></p>
+      <p><strong>Datei:</strong> <span data-state="secondary-item">{{ state.secondary_media_path or state.secondary_item or '–' }}</span></p>
+      <p><strong>Status:</strong> <span data-state="secondary-status">{{ state.secondary_status or 'unbekannt' }}</span></p>
+      <p><strong>Gestartet:</strong> <span data-state="secondary-started">{% if state.secondary_started_at %}{{ state.secondary_started_at | datetimeformat }}{% else %}–{% endif %}</span></p>
+      <div class="status-preview" data-preview="secondary">
+        <div class="status-preview__frame">
+          <img data-preview-image="secondary" src="{{ url_for('state_preview', side='secondary') }}" alt="Vorschau sekundäre Anzeige" hidden />
+          <span data-preview-placeholder="secondary" class="status-preview__placeholder">Keine Vorschau verfügbar</span>
+        </div>
+      </div>
     </div>
     {% endif %}
-    <p><strong>Infobildschirm:</strong> {% if state.info_screen %}aktiv{% else %}inaktiv{% endif %}{% if state.info_manual %} (manuell){% endif %}</p>
+    <p><strong>Infobildschirm:</strong> <span data-state="info-screen">{% if state.info_screen %}aktiv{% else %}inaktiv{% endif %}{% if state.info_manual %} (manuell){% endif %}</span></p>
     <p><strong>Service-Status:</strong> {{ service_status or 'unbekannt' }}</p>
     <p><strong>Autostart:</strong> {% if config.playback.auto_start %}aktiviert{% else %}deaktiviert{% endif %}</p>
   </article>
@@ -31,6 +53,7 @@
         <thead>
           <tr>
             <th>#</th>
+            <th>Vorschau</th>
             <th>Datei</th>
             <th>Quelle</th>
             <th>Typ</th>
@@ -40,13 +63,20 @@
           {% for item in playlist %}
           <tr>
             <td>{{ loop.index }}</td>
+            <td>
+              {% if item.type == 'image' %}
+              <img class="playlist-preview" src="{{ url_for('media_preview', source=item.source, media_path=item.path) }}" alt="Vorschau von {{ item.path }}" loading="lazy" />
+              {% else %}
+              <span class="muted">—</span>
+              {% endif %}
+            </td>
             <td>{{ item.path }}</td>
             <td>{{ item.source }}</td>
             <td>{{ item.type }}</td>
           </tr>
           {% else %}
           <tr>
-            <td colspan="4">Keine Medien gefunden. Bitte prüfen, ob die Quellen erreichbar sind.</td>
+            <td colspan="5">Keine Medien gefunden. Bitte prüfen, ob die Quellen erreichbar sind.</td>
           </tr>
           {% endfor %}
         </tbody>
@@ -55,4 +85,129 @@
     <a class="button-link" href="{{ url_for('media_settings') }}">Quellen verwalten</a>
   </article>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    const stateTargets = {
+      primaryItem: document.querySelector('[data-state="primary-item"]'),
+      primaryStatus: document.querySelector('[data-state="primary-status"]'),
+      primaryStarted: document.querySelector('[data-state="primary-started"]'),
+      primarySource: document.querySelector('[data-state="primary-source"]'),
+      secondaryItem: document.querySelector('[data-state="secondary-item"]'),
+      secondaryStatus: document.querySelector('[data-state="secondary-status"]'),
+      secondaryStarted: document.querySelector('[data-state="secondary-started"]'),
+      secondarySource: document.querySelector('[data-state="secondary-source"]'),
+      infoScreen: document.querySelector('[data-state="info-screen"]'),
+    };
+
+    const statusIndicators = {
+      service: document.querySelector('[data-status="service"]'),
+      info: document.querySelector('[data-status="info"]'),
+    };
+
+    const secondaryBlock = document.querySelector('[data-secondary-status]');
+    const previewImages = {
+      primary: document.querySelector('[data-preview-image="primary"]'),
+      secondary: document.querySelector('[data-preview-image="secondary"]'),
+    };
+    const previewPlaceholders = {
+      primary: document.querySelector('[data-preview-placeholder="primary"]'),
+      secondary: document.querySelector('[data-preview-placeholder="secondary"]'),
+    };
+    const previewUrls = {
+      primary: "{{ url_for('state_preview', side='primary') }}",
+      secondary: "{{ url_for('state_preview', side='secondary') }}",
+    };
+    const formatter = new Intl.DateTimeFormat('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+
+    function formatTimestamp(value) {
+      if (!value) {
+        return '–';
+      }
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) {
+        return '–';
+      }
+      return formatter.format(new Date(numeric * 1000));
+    }
+
+    function setIndicator(element, active, activeClass, inactiveClass, activeLabel, inactiveLabel) {
+      if (!element) {
+        return;
+      }
+      element.classList.remove('status-indicator--ok', 'status-indicator--down', 'status-indicator--info', 'status-indicator--neutral');
+      element.classList.add(active ? activeClass : inactiveClass);
+      element.textContent = active ? activeLabel : inactiveLabel;
+    }
+
+    function updatePreview(side, available, token, mediaType) {
+      const image = previewImages[side];
+      const placeholder = previewPlaceholders[side];
+      if (!image || !placeholder) {
+        return;
+      }
+      if (available) {
+        image.hidden = false;
+        image.src = `${previewUrls[side]}?t=${token || 0}`;
+        placeholder.hidden = true;
+      } else {
+        image.hidden = true;
+        placeholder.hidden = false;
+        placeholder.textContent = mediaType === 'video' ? 'Video in Wiedergabe' : 'Keine Vorschau verfügbar';
+      }
+    }
+
+    async function refreshState() {
+      try {
+        const response = await fetch('{{ url_for('api_state') }}', { cache: 'no-store' });
+        if (!response.ok) {
+          return;
+        }
+        const data = await response.json();
+        if (stateTargets.primaryItem) stateTargets.primaryItem.textContent = data.primary_media_path || data.primary_item || '–';
+        if (stateTargets.primaryStatus) stateTargets.primaryStatus.textContent = data.primary_status || 'unbekannt';
+        if (stateTargets.primaryStarted) stateTargets.primaryStarted.textContent = formatTimestamp(data.primary_started_at);
+        if (stateTargets.primarySource) stateTargets.primarySource.textContent = data.primary_source || '–';
+
+        const hasSecondary = Boolean(data.secondary_item || data.secondary_status || data.secondary_started_at);
+        if (secondaryBlock) {
+          secondaryBlock.style.display = hasSecondary ? '' : 'none';
+        }
+        if (stateTargets.secondaryItem) stateTargets.secondaryItem.textContent = data.secondary_media_path || data.secondary_item || '–';
+        if (stateTargets.secondaryStatus) stateTargets.secondaryStatus.textContent = data.secondary_status || 'unbekannt';
+        if (stateTargets.secondaryStarted) stateTargets.secondaryStarted.textContent = formatTimestamp(data.secondary_started_at);
+        if (stateTargets.secondarySource) stateTargets.secondarySource.textContent = data.secondary_source || '–';
+
+        if (stateTargets.infoScreen) {
+          const parts = [];
+          parts.push(data.info_screen ? 'aktiv' : 'inaktiv');
+          if (data.info_manual) {
+            parts.push('(manuell)');
+          }
+          stateTargets.infoScreen.textContent = parts.join(' ');
+        }
+
+        updatePreview('primary', data.primary_preview_available, data.primary_preview_token, data.primary_media_type);
+        updatePreview('secondary', data.secondary_preview_available, data.secondary_preview_token, data.secondary_media_type);
+
+        setIndicator(statusIndicators.service, Boolean(data.service_active), 'status-indicator--ok', 'status-indicator--down', 'Dienst läuft', 'Dienst ist inaktiv');
+        setIndicator(statusIndicators.info, Boolean(data.info_screen), 'status-indicator--info', 'status-indicator--neutral', 'Infobildschirm aktiv', 'Infobildschirm aus');
+      } catch (err) {
+        console.debug('Status konnte nicht aktualisiert werden', err);
+      }
+    }
+
+    refreshState();
+    setInterval(refreshState, 5000);
+  })();
+</script>
 {% endblock %}

--- a/slideshow/templates/edit_source.html
+++ b/slideshow/templates/edit_source.html
@@ -1,0 +1,48 @@
+{% extends 'layout.html' %}
+{% block title %}Quelle bearbeiten – Slideshow{% endblock %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Quelle „{{ source.name }}“ bearbeiten</h2>
+    <p class="muted">Passe Server, Freigabe oder Zugangsdaten an. Leer gelassene Felder behalten den aktuellen Wert.</p>
+    <form method="post" class="grid-form">
+      <label>Bezeichnung
+        <input type="text" name="name" value="{{ request.form.get('name', source.name) }}" required />
+      </label>
+      <label>SMB-Pfad (optional)
+        <input type="text" name="smb_path" placeholder="smb://server/freigabe/unterordner" value="{{ request.form.get('smb_path', smb_prefill) }}" />
+        <small class="muted">Optionaler Gesamtpfad zur Freigabe, z. B. <code>smb://server/share/ordner</code>.</small>
+      </label>
+      <label>Server
+        <input type="text" name="server" value="{{ request.form.get('server', source.options.get('server', '')) }}" />
+      </label>
+      <label>Freigabe
+        <input type="text" name="share" value="{{ request.form.get('share', source.options.get('share', '')) }}" />
+      </label>
+      <label>Unterordner (optional)
+        <input type="text" name="subpath" value="{{ request.form.get('subpath', source.subpath or '') }}" />
+      </label>
+      <label>Benutzername (optional)
+        <input type="text" name="username" value="{{ request.form.get('username', source.options.get('username', '')) }}" autocomplete="username" />
+      </label>
+      <label>Domäne (optional)
+        <input type="text" name="domain" value="{{ request.form.get('domain', source.options.get('domain', '')) }}" />
+      </label>
+      <label>Neues Passwort (optional)
+        <input type="password" name="password" autocomplete="new-password" />
+        <small class="muted">Leer lassen, um das bestehende Passwort beizubehalten.</small>
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="clear_password" value="1" /> Gespeichertes Passwort entfernen
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" name="auto_scan" value="1" {% if (request.form and request.form.get('auto_scan')) or (not request.form and source.auto_scan) %}checked{% endif %} /> Automatisch scannen
+      </label>
+      <div class="button-row">
+        <button type="submit">Änderungen speichern</button>
+        <a class="button-link" href="{{ url_for('media_settings') }}">Abbrechen</a>
+      </div>
+    </form>
+  </article>
+</section>
+{% endblock %}

--- a/slideshow/templates/layout.html
+++ b/slideshow/templates/layout.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Slideshow{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   </head>
-  <body>
+  <body class="theme-{{ current_theme or 'mid' }}">
     <header class="topbar">
       <h1>Slideshow Steuerung</h1>
       <div class="version">Version {{ slideshow_version }}</div>

--- a/slideshow/templates/login.html
+++ b/slideshow/templates/login.html
@@ -6,7 +6,7 @@
     <title>Login – Slideshow</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
   </head>
-  <body class="login-page">
+  <body class="login-page theme-{{ current_theme or 'mid' }}">
     <form class="login-form" method="post">
       <h1>Anmeldung</h1>
       <label for="username">Benutzername</label>

--- a/slideshow/templates/media.html
+++ b/slideshow/templates/media.html
@@ -33,6 +33,9 @@
             </td>
             <td>
               <div class="table-actions">
+                {% if source.type == 'smb' %}
+                <a class="button-link" href="{{ url_for('edit_source', name=source.name) }}">Bearbeiten</a>
+                {% endif %}
                 <form method="post" action="{{ url_for('toggle_auto_scan', name=source.name) }}">
                   {% if source.auto_scan %}
                   <input type="hidden" name="enabled" value="0" />

--- a/slideshow/templates/network.html
+++ b/slideshow/templates/network.html
@@ -7,25 +7,29 @@
     <p class="muted">Änderungen am Netzwerk erfordern Administratorrechte und führen ggf. zu einer kurzfristigen Unterbrechung der Verbindung.</p>
     <form method="post" action="{{ url_for('update_network') }}" class="grid-form">
       <label>Hostname
-        <input type="text" name="hostname" value="{{ config.network.hostname or '' }}" placeholder="raspberrypi" />
+        <input type="text" name="hostname" value="{{ current.hostname or config.network.hostname or '' }}" placeholder="raspberrypi" />
       </label>
       <label>Interface
-        <input type="text" name="interface" value="{{ config.network.interface }}" />
+        <input type="text" name="interface" value="{{ current.interface or config.network.interface }}" />
       </label>
       <label>Modus
         <select name="mode">
-          <option value="dhcp" {% if config.network.mode == 'dhcp' %}selected{% endif %}>DHCP</option>
-          <option value="static" {% if config.network.mode == 'static' %}selected{% endif %}>Statisch</option>
+          {% set mode = current.mode or config.network.mode %}
+          <option value="dhcp" {% if mode == 'dhcp' %}selected{% endif %}>DHCP</option>
+          <option value="static" {% if mode == 'static' %}selected{% endif %}>Statisch</option>
         </select>
       </label>
       <label>Statische Adresse (CIDR)
-        <input type="text" name="address" value="{{ config.network.static.address }}" />
+        {% set address = current.address or config.network.static.address %}
+        <input type="text" name="address" value="{{ address or '' }}" />
       </label>
       <label>Gateway
-        <input type="text" name="router" value="{{ config.network.static.router }}" />
+        {% set router = current.router or config.network.static.router %}
+        <input type="text" name="router" value="{{ router or '' }}" />
       </label>
       <label>DNS-Server (kommagetrennt)
-        <input type="text" name="dns" value="{{ config.network.static.dns | join(',') }}" />
+        {% set dns_value = current.dns or config.network.static.dns %}
+        <input type="text" name="dns" value="{{ dns_value | join(',') if dns_value else '' }}" />
       </label>
       <button type="submit">Einstellungen übernehmen</button>
     </form>
@@ -36,7 +40,9 @@
     <ul class="hint-list">
       <li>Bei einer statischen Konfiguration sollten Adresse, Gateway und DNS-Server in demselben Subnetz liegen.</li>
       <li>Nach Änderungen empfiehlt sich ein kurzer Neustart der Netzwerkverbindung oder des Systems.</li>
-      <li>Der aktuelle Hostname lautet <strong>{{ config.network.hostname or 'unbekannt' }}</strong>.</li>
+      <li>Der aktuelle Hostname lautet <strong>{{ current.hostname or config.network.hostname or 'unbekannt' }}</strong>.</li>
+      <li>Aktive Adresse: <strong>{{ current.address or 'unbekannt' }}</strong>{% if current.router %}, Gateway: <strong>{{ current.router }}</strong>{% endif %}.</li>
+      {% if current.dns %}<li>DNS-Server laut System: <strong>{{ current.dns | join(', ') }}</strong></li>{% endif %}
     </ul>
   </article>
 </section>

--- a/slideshow/templates/playback.html
+++ b/slideshow/templates/playback.html
@@ -48,9 +48,9 @@
       </label>
       <label>Übergang
         <select name="transition_type">
-          <option value="none" {% if config.playback.transition_type == 'none' %}selected{% endif %}>Keiner</option>
-          <option value="fade" {% if config.playback.transition_type == 'fade' %}selected{% endif %}>Fade</option>
-          <option value="slide" {% if config.playback.transition_type == 'slide' %}selected{% endif %}>Slide</option>
+          {% for value, label in transition_options %}
+          <option value="{{ value }}" {% if config.playback.transition_type == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
         </select>
       </label>
       <label>Übergangsdauer (Sekunden)
@@ -70,9 +70,16 @@
       <fieldset class="splitscreen">
         <legend>Splitscreen</legend>
         <label class="checkbox">
-          <input type="checkbox" name="splitscreen_enabled" value="1" {% if config.playback.splitscreen_enabled %}checked{% endif %} /> Aktivieren
+          <input type="checkbox" id="splitscreen-toggle" name="splitscreen_enabled" value="1" {% if config.playback.splitscreen_enabled %}checked{% endif %} /> Aktivieren
         </label>
-        <div class="split-grid">
+        <label class="split-ratio" {% if not config.playback.splitscreen_enabled %}hidden{% endif %}>
+          Aufteilung (links/rechts)
+          <div class="split-ratio__controls">
+            <input type="range" min="10" max="90" name="splitscreen_ratio" id="splitscreen-ratio" value="{{ config.playback.splitscreen_ratio }}" />
+            <span class="muted"><span id="splitscreen-ratio-label">{{ config.playback.splitscreen_ratio }}</span>% links</span>
+          </div>
+        </label>
+        <div class="split-grid" {% if not config.playback.splitscreen_enabled %}hidden{% endif %}>
           <div>
             <h4>Linke Seite</h4>
             <label>Quelle
@@ -107,4 +114,41 @@
     </form>
   </article>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    const toggle = document.getElementById('splitscreen-toggle');
+    const grid = document.querySelector('.split-grid');
+    const ratioWrapper = document.querySelector('.split-ratio');
+    const ratioInput = document.getElementById('splitscreen-ratio');
+    const ratioLabel = document.getElementById('splitscreen-ratio-label');
+    if (!toggle || !grid) {
+      return;
+    }
+
+    const updateVisibility = () => {
+      grid.hidden = !toggle.checked;
+      if (ratioWrapper) {
+        ratioWrapper.hidden = !toggle.checked;
+      }
+    };
+
+    const updateLabel = () => {
+      if (!ratioInput || !ratioLabel) {
+        return;
+      }
+      ratioLabel.textContent = ratioInput.value;
+    };
+
+    toggle.addEventListener('change', updateVisibility);
+    if (ratioInput) {
+      ratioInput.addEventListener('input', updateLabel);
+      ratioInput.addEventListener('change', updateLabel);
+      updateLabel();
+    }
+    updateVisibility();
+  })();
+</script>
 {% endblock %}

--- a/slideshow/templates/system.html
+++ b/slideshow/templates/system.html
@@ -28,7 +28,12 @@
 
   <article>
     <h2>Service &amp; Aktionen</h2>
-    <p><strong>Service-Status:</strong> {{ service_status or 'unbekannt' }}</p>
+    <div class="status-flags">
+      <span class="status-indicator {% if service_active %}status-indicator--ok{% else %}status-indicator--down{% endif %}">
+        {% if service_active %}Dienst läuft{% else %}Dienst ist inaktiv{% endif %}
+      </span>
+      <span class="muted">Status laut systemd: {{ service_status or 'unbekannt' }}</span>
+    </div>
     <div class="button-row">
       <form method="post" action="{{ url_for('system_service', action='restart') }}">
         <button type="submit">Service neu starten</button>
@@ -50,6 +55,30 @@
     </div>
   </article>
 
+  <article>
+    <h2>Konfiguration</h2>
+    <div class="button-row">
+      <a class="button-link" href="{{ url_for('export_config') }}">Konfiguration exportieren</a>
+    </div>
+    <form method="post" action="{{ url_for('import_config') }}" enctype="multipart/form-data" class="inline-form">
+      <label>Datei auswählen
+        <input type="file" name="config_file" accept=".zip,.yml,.yaml,.json" required />
+      </label>
+      <button type="submit">Konfiguration importieren</button>
+      <p class="muted">Unterstützt werden exportierte ZIP-Archive oder eine einzelne <code>config.yml</code>.</p>
+    </form>
+    <form method="post" action="{{ url_for('update_theme') }}" class="inline-form theme-form">
+      <label>Theme auswählen
+        <select name="theme">
+          {% for value, label in theme_choices %}
+          <option value="{{ value }}" {% if config.ui.theme == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <button type="submit">Theme übernehmen</button>
+    </form>
+  </article>
+
   <article class="logs">
     <h2>Protokolle</h2>
     <div class="log-controls">
@@ -64,6 +93,7 @@
         <input type="number" id="log-lines" value="200" min="10" max="2000" />
       </label>
       <button type="button" id="log-refresh">Aktualisieren</button>
+      <a id="log-download" class="button-link" href="#" download>Herunterladen</a>
     </div>
     <pre id="log-output">Wähle ein Log aus, um den Inhalt zu laden.</pre>
   </article>
@@ -78,7 +108,9 @@
     const output = document.getElementById('log-output');
     const linesInput = document.getElementById('log-lines');
     const refresh = document.getElementById('log-refresh');
+    const downloadLink = document.getElementById('log-download');
     const baseUrl = "{{ url_for('show_log', name='__LOG__') }}";
+    const downloadBase = "{{ url_for('download_log', name='__LOG__') }}";
 
     async function loadLog() {
       if (!select || !output) {
@@ -88,7 +120,15 @@
       const lines = linesInput && linesInput.value ? linesInput.value : '200';
       if (!name) {
         output.textContent = 'Keine Logdatei ausgewählt.';
+        if (downloadLink) {
+          downloadLink.classList.add('is-disabled');
+          downloadLink.href = '#';
+        }
         return;
+      }
+      if (downloadLink) {
+        downloadLink.classList.remove('is-disabled');
+        downloadLink.href = downloadBase.replace('__LOG__', encodeURIComponent(name));
       }
       output.textContent = 'Lade Log …';
       try {
@@ -116,6 +156,9 @@
 
     if (select && select.value) {
       loadLog();
+    } else if (downloadLink) {
+      downloadLink.classList.add('is-disabled');
+      downloadLink.href = '#';
     }
   });
 </script>


### PR DESCRIPTION
## Summary
- add UI polish including downloadable logs, split-screen ratio controls, and refreshed theme variables
- fix dashboard previews with API/token updates and direct state preview endpoints that surface the active image
- harden playback/media logic for split-screen playlists, cached assets, and dynamic version reporting

## Testing
- python -m compileall slideshow

------
https://chatgpt.com/codex/tasks/task_e_68df75447ab0832dac1864747d9d2b72