### PR TITLE
Persist playlist selections and fix splitscreen paths

### DIFF
--- a/API.md
+++ b/API.md
@@ -118,7 +118,7 @@ Liefert ein kleines JPEG-Vorschaubild für Bilddateien einer Quelle. Für andere
 
 ### `GET /logs/<name>/download`
 
-Lädt eine komplette Logdatei als Text herunter. Der Parameter `<name>` entspricht einem Schlüssel aus der Logauswahl des System-Tabs (`app`, `player`, `media`, `network`, `system`).
+Lädt eine komplette Logdatei als Text herunter. Der Parameter `<name>` entspricht einem Schlüssel aus der Logauswahl des System-Tabs (`app`, `player`, `media`, `network`, `system`, `update`).
 
 ## Systemverwaltung
 

--- a/slideshow/app.py
+++ b/slideshow/app.py
@@ -9,7 +9,7 @@ import logging
 import mimetypes
 import pathlib
 import subprocess
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from flask import (
     Flask,
@@ -27,7 +27,7 @@ from flask_login import LoginManager, current_user, login_required, login_user, 
 
 from . import __version__
 from .auth import PamAuthenticator, User
-from .config import AppConfig, export_config_bundle, import_config_bundle
+from .config import AppConfig, PlaylistItem, export_config_bundle, import_config_bundle
 from .logging_config import available_logs
 from .media import MediaManager
 from .network import NetworkManager
@@ -58,6 +58,17 @@ THEME_CHOICES: Tuple[Tuple[str, str], ...] = (
     ("light", "Hell"),
     ("mid", "Neutral"),
     ("dark", "Dunkel"),
+)
+
+DISPLAY_RESOLUTION_CHOICES: Tuple[Tuple[str, str], ...] = (
+    ("3840x2160", "4K UHD (3840×2160)"),
+    ("2560x1440", "QHD (2560×1440)"),
+    ("2560x1080", "Ultra-Wide HD (2560×1080)"),
+    ("1920x1200", "WUXGA (1920×1200)"),
+    ("1920x1080", "Full HD (1920×1080)"),
+    ("1600x900", "HD+ (1600×900)"),
+    ("1366x768", "WXGA (1366×768)"),
+    ("1280x720", "HD (1280×720)"),
 )
 
 
@@ -156,15 +167,102 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     def dashboard():
         state = get_state()
         playlist_preview = media_manager.build_playlist()
+        split_left: List[PlaylistItem] = []
+        split_right: List[PlaylistItem] = []
+        if cfg.playback.splitscreen_enabled:
+            split_left, split_right = media_manager.build_splitscreen_playlists(
+                cfg.playback.splitscreen_left_source,
+                cfg.playback.splitscreen_left_path,
+                cfg.playback.splitscreen_right_source,
+                cfg.playback.splitscreen_right_path,
+            )
         service_status = system_manager.service_status()
+        disabled_keys = media_manager.disabled_media_keys()
         return render_template(
             "dashboard.html",
             state=state,
             playlist=playlist_preview,
+            splitscreen_left=split_left,
+            splitscreen_right=split_right,
             config=cfg,
             service_status=service_status,
             service_active=service_active(service_status),
+            disabled_keys=disabled_keys,
         )
+
+    @app.route("/playlist/selection", methods=["POST"])
+    @pam_required
+    def update_playlist_selection():
+        redirect_target = request.form.get("next") or url_for("dashboard")
+
+        def _normalize_key(raw: str) -> Optional[tuple[str, str]]:
+            if not raw or "|" not in raw:
+                return None
+            source, path = raw.split("|", 1)
+            return media_manager.normalize_media_entry(source, path)
+
+        normalized_map: Dict[str, tuple[str, str]] = {}
+        invalid = False
+        for raw in request.form.getlist("all_media"):
+            normalized_pair = _normalize_key(raw)
+            if not normalized_pair:
+                if raw:
+                    invalid = True
+                continue
+            key = f"{normalized_pair[0]}|{normalized_pair[1]}"
+            normalized_map[key] = normalized_pair
+
+        enabled_raw = set(request.form.getlist("enabled_media"))
+        enabled_keys = {key for key in enabled_raw if key in normalized_map}
+
+        previous_entries = getattr(cfg.playback, "disabled_media", []) or []
+        previous_map: Dict[str, tuple[str, str]] = {}
+        for entry in previous_entries:
+            if isinstance(entry, dict):
+                entry_source = str(entry.get("source") or "").strip()
+                entry_path = str(entry.get("path") or "").strip()
+            else:
+                entry_source = str(getattr(entry, "source", "") or "").strip()
+                entry_path = str(getattr(entry, "path", "") or "").strip()
+            normalized_pair = media_manager.normalize_media_entry(entry_source, entry_path)
+            if not normalized_pair:
+                continue
+            key = f"{normalized_pair[0]}|{normalized_pair[1]}"
+            previous_map[key] = normalized_pair
+
+        preserved = {
+            key: pair for key, pair in previous_map.items() if key not in normalized_map
+        }
+        disabled_keys = set(normalized_map.keys()) - enabled_keys
+
+        updated_map = {**preserved}
+        for key in disabled_keys:
+            updated_map[key] = normalized_map[key]
+
+        current_pairs = set(previous_map.values())
+        new_pairs = set(updated_map.values())
+
+        if new_pairs != current_pairs:
+            serialized = [
+                {"source": source, "path": path}
+                for source, path in sorted(
+                    new_pairs, key=lambda item: (item[0].lower(), item[1].lower())
+                )
+            ]
+            cfg.playback.disabled_media = serialized
+            cfg.save()
+            player.reload()
+            flash("Auswahl gespeichert", "success")
+        else:
+            if invalid:
+                flash("Einige Einträge konnten nicht verarbeitet werden", "warning")
+            else:
+                flash("Keine Änderungen erkannt", "info")
+
+        if invalid and new_pairs != current_pairs:
+            flash("Einige Einträge konnten nicht verarbeitet werden", "warning")
+
+        return redirect(redirect_target)
 
     @app.route("/media/preview/<string:source>/<path:media_path>")
     @pam_required
@@ -246,7 +344,8 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             share = (request.form.get("share") or "").strip() or None
             username = (request.form.get("username") or "").strip()
             domain = (request.form.get("domain") or "").strip()
-            subpath = (request.form.get("subpath") or "").strip() or None
+            subpath_raw = request.form.get("subpath")
+            subpath = subpath_raw.strip() if subpath_raw is not None else None
             auto_scan = request.form.get("auto_scan") is not None
             password_raw = request.form.get("password")
             password_action = request.form.get("clear_password")
@@ -287,10 +386,11 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             share_opt = source.options.get("share")
             subpath_value = request.form.get("subpath") if request.form else source.subpath
             if server_opt and share_opt:
-                smb_prefill = f"smb://{server_opt}/{share_opt}"
+                smb_prefill = "\\\\" + str(server_opt)
+                smb_prefill += "\\" + str(share_opt)
                 normalized_sub = (subpath_value or "").replace("\\", "/").strip("/")
                 if normalized_sub:
-                    smb_prefill = f"{smb_prefill.rstrip('/')}/{normalized_sub}"
+                    smb_prefill = smb_prefill.rstrip("\\/") + "\\" + normalized_sub.replace("/", "\\")
             else:
                 smb_prefill = ""
         return render_template("edit_source.html", source=source, smb_prefill=smb_prefill or "")
@@ -299,12 +399,17 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     @pam_required
     def playback_settings_page():
         sources = media_manager.list_sources()
+        detected_resolution = system_manager.detect_display_resolution()
+        resolution_values = [value for value, _ in DISPLAY_RESOLUTION_CHOICES]
         return render_template(
             "playback.html",
             config=cfg,
             sources=sources,
             state=get_state(),
             transition_options=TRANSITION_OPTIONS,
+            display_resolution_choices=DISPLAY_RESOLUTION_CHOICES,
+            detected_resolution=detected_resolution,
+            resolution_values=resolution_values,
         )
 
     @app.route("/network")
@@ -322,13 +427,19 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     def system_settings():
         branches = system_manager.list_branches()
         current_branch = system_manager.current_branch()
+        branch_choices: List[str] = []
+        if current_branch:
+            branch_choices.append(current_branch)
+        for branch in branches:
+            if branch not in branch_choices:
+                branch_choices.append(branch)
         service_status = system_manager.service_status()
         return render_template(
             "system.html",
             config=cfg,
-            branches=branches,
+            branch_choices=branch_choices,
             current_branch=current_branch,
-            has_branch_info=bool(branches or current_branch),
+            has_branch_info=bool(branch_choices),
             fallback_repo=system_manager.fallback_repo,
             service_status=service_status,
             service_active=service_active(service_status),
@@ -599,28 +710,33 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
             transition_duration = playback.transition_duration
         playback.transition_duration = max(0.2, min(10.0, transition_duration))
 
-        display_resolution = (request.form.get("display_resolution") or playback.display_resolution).strip()
-        playback.display_resolution = display_resolution
+        resolution_choice = (request.form.get("display_resolution_choice") or "").strip()
+        custom_resolution = (request.form.get("display_resolution_custom") or "").strip()
+        if resolution_choice == "custom":
+            display_resolution = custom_resolution or playback.display_resolution
+        elif resolution_choice:
+            display_resolution = resolution_choice
+        else:
+            display_resolution = playback.display_resolution
+        playback.display_resolution = (display_resolution or playback.display_resolution).strip()
 
         playback.video_player_args = parse_args("video_player_args", playback.video_player_args)
         playback.image_viewer_args = parse_args("image_viewer_args", playback.image_viewer_args)
 
         splitscreen_enabled = request.form.get("splitscreen_enabled") in {"1", "true", "on"}
         playback.splitscreen_enabled = splitscreen_enabled
-        left_source = request.form.get("splitscreen_left_source")
-        right_source = request.form.get("splitscreen_right_source")
-        def _normalize_split_path(raw: Optional[str]) -> str:
-            if not raw:
-                return ""
-            return str(raw).strip().replace("\\", "/")
+        left_source = request.form.get("splitscreen_left_source") or None
+        right_source = request.form.get("splitscreen_right_source") or None
 
-        playback.splitscreen_left_source = left_source or None
-        playback.splitscreen_left_path = _normalize_split_path(
-            request.form.get("splitscreen_left_path")
+        playback.splitscreen_left_source = left_source
+        playback.splitscreen_left_path = media_manager.normalize_split_path(
+            left_source,
+            request.form.get("splitscreen_left_path"),
         )
-        playback.splitscreen_right_source = right_source or None
-        playback.splitscreen_right_path = _normalize_split_path(
-            request.form.get("splitscreen_right_path")
+        playback.splitscreen_right_source = right_source
+        playback.splitscreen_right_path = media_manager.normalize_split_path(
+            right_source,
+            request.form.get("splitscreen_right_path"),
         )
         try:
             ratio_value = int(request.form.get("splitscreen_ratio") or playback.splitscreen_ratio)
@@ -636,11 +752,16 @@ def create_app(config: Optional[AppConfig] = None, player_service: Optional[Play
     @app.route("/system/update", methods=["POST"])
     @pam_required
     def system_update():
-        branch = request.form.get("branch") or system_manager.current_branch() or "main"
+        branch = (request.form.get("branch") or "").strip()
+        if not branch:
+            branch = system_manager.current_branch() or "main"
         try:
             system_manager.update(branch)
-            flash(f"Update auf Branch {branch} gestartet", "success")
-        except (subprocess.CalledProcessError, RuntimeError) as exc:
+            flash(
+                f"Update auf Branch {branch} gestartet. Details siehe update.log im System-Tab.",
+                "success",
+            )
+        except (subprocess.CalledProcessError, RuntimeError, OSError) as exc:
             LOGGER.exception("Update fehlgeschlagen")
             flash(f"Update fehlgeschlagen: {exc}", "danger")
         except ValueError as exc:

--- a/slideshow/config.py
+++ b/slideshow/config.py
@@ -77,6 +77,7 @@ DEFAULT_CONFIG = {
         "splitscreen_right_source": None,
         "splitscreen_right_path": "",
         "splitscreen_ratio": 50,
+        "disabled_media": [],
     },
     "network": {
         "hostname": None,
@@ -147,6 +148,7 @@ class PlaybackConfig:
     splitscreen_right_source: Optional[str]
     splitscreen_right_path: str
     splitscreen_ratio: int
+    disabled_media: List[Dict[str, Any]]
 
 
 @dataclasses.dataclass

--- a/slideshow/logging_config.py
+++ b/slideshow/logging_config.py
@@ -123,5 +123,9 @@ def available_logs() -> Dict[str, dict]:
             "label": definition["label"],
             "path": LOG_DIR / definition["filename"],
         }
+    result["update"] = {
+        "label": "Update-Protokoll",
+        "path": LOG_DIR / "update.log",
+    }
     return result
 

--- a/slideshow/media.py
+++ b/slideshow/media.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import io
 from dataclasses import asdict
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from PIL import Image
 
@@ -97,6 +97,122 @@ class MediaManager:
         ensure_cache_dir()
         self._migrate_mount_points()
         self._ensure_local_directories()
+
+    # Zustandsabfragen -------------------------------------------------
+    def _disabled_media_pairs(self) -> set[Tuple[str, str]]:
+        pairs: set[Tuple[str, str]] = set()
+        entries = getattr(self.config.playback, "disabled_media", []) or []
+        for entry in entries:
+            source: Optional[str]
+            path: Optional[str]
+            if isinstance(entry, dict):
+                source = entry.get("source")
+                path = entry.get("path")
+            elif isinstance(entry, PlaylistItem):
+                source = entry.source
+                path = entry.path
+            else:
+                source = getattr(entry, "source", None)
+                path = getattr(entry, "path", None)
+            normalized = self.normalize_media_entry(source, path)
+            if normalized:
+                pairs.add(normalized)
+        return pairs
+
+    def disabled_media_keys(self) -> set[str]:
+        return {f"{source}|{path}" for source, path in self._disabled_media_pairs()}
+
+    def normalize_media_entry(
+        self, source: Optional[str], path: Optional[str]
+    ) -> Optional[Tuple[str, str]]:
+        normalized_source = str(source or "").strip()
+        normalized_path_raw = str(path or "")
+        normalized_path = _normalize_subpath(normalized_path_raw)
+        if normalized_path is None:
+            normalized_path = normalized_path_raw.replace("\\", "/")
+            normalized_path = normalized_path.strip()
+            normalized_path = re.sub(r"/{2,}", "/", normalized_path)
+            normalized_path = normalized_path.strip("/")
+        if not normalized_source or not normalized_path:
+            return None
+        return normalized_source, normalized_path
+
+    def _relative_from_filesystem(self, source: MediaSource, raw: str) -> Optional[str]:
+        if not raw:
+            return None
+        try:
+            path_obj = pathlib.Path(raw)
+        except Exception:  # pragma: no cover - defensive
+            return None
+        try:
+            if path_obj.is_absolute():
+                relative = path_obj.relative_to(pathlib.Path(source.path))
+                normalized = _normalize_subpath(str(relative))
+                if not normalized:
+                    return None
+                configured = _normalize_subpath(source.subpath)
+                if configured:
+                    conf_parts = [part for part in configured.split("/") if part]
+                    rel_parts = [part for part in normalized.split("/") if part]
+                    if len(rel_parts) >= len(conf_parts) and [
+                        part.lower() for part in rel_parts[: len(conf_parts)]
+                    ] == [part.lower() for part in conf_parts]:
+                        rel_parts = rel_parts[len(conf_parts) :]
+                        normalized = "/".join(rel_parts)
+                return normalized or None
+        except ValueError:
+            return None
+        return None
+
+    def _normalize_split_base(self, source: MediaSource, raw: Optional[str]) -> Optional[str]:
+        if raw is None:
+            return None
+        raw_str = str(raw).strip()
+        if not raw_str:
+            return None
+        fs_relative = self._relative_from_filesystem(source, raw_str)
+        sanitized = re.sub(r"^smb://", "", raw_str, flags=re.IGNORECASE)
+        sanitized = sanitized.replace("\\", "/").strip()
+        sanitized = sanitized.strip("/")
+        parts = [part for part in sanitized.split("/") if part]
+        if parts and ":" in parts[0]:
+            parts = parts[1:]
+        if source.type == "smb":
+            server = str(source.options.get("server") or "").strip().strip("\\/")
+            share = str(source.options.get("share") or "").strip().strip("\\/")
+            if server and share and len(parts) >= 2:
+                if parts[0].lower() == server.lower() and parts[1].lower() == share.lower():
+                    parts = parts[2:]
+        configured = _normalize_subpath(source.subpath)
+        if configured:
+            conf_parts = [part for part in configured.split("/") if part]
+            if len(parts) >= len(conf_parts) and [
+                part.lower() for part in parts[: len(conf_parts)]
+            ] == [part.lower() for part in conf_parts]:
+                parts = parts[len(conf_parts) :]
+        candidate = "/".join(parts)
+        if candidate:
+            return candidate
+        return fs_relative
+
+    def normalize_split_path(self, source_name: Optional[str], raw: Optional[str]) -> str:
+        if not raw:
+            return ""
+        raw_str = str(raw).strip()
+        if not raw_str:
+            return ""
+        source = self.config.get_source(source_name) if source_name else None
+        if source:
+            normalized = self._normalize_split_base(source, raw_str)
+            if normalized:
+                return normalized
+        cleaned = re.sub(r"^smb://", "", raw_str, flags=re.IGNORECASE)
+        cleaned = cleaned.replace("\\", "/").strip("/")
+        parts = [part for part in cleaned.split("/") if part]
+        if parts and ":" in parts[0]:
+            parts = parts[1:]
+        cleaned = "/".join(parts)
+        return cleaned
 
     # Initialisierungs-Helfer --------------------------------------------
     def _is_mount_active(self, mount_point: pathlib.Path) -> bool:
@@ -321,7 +437,15 @@ class MediaManager:
         if smb_path:
             server, share, parsed_subpath = parse_smb_location(smb_path)
 
-        normalized_subpath = _normalize_subpath(subpath or parsed_subpath or source.subpath)
+        normalized_subpath: Optional[str]
+        if subpath is not None:
+            normalized_subpath = _normalize_subpath(subpath)
+            if normalized_subpath is None and not source.subpath and parsed_subpath:
+                normalized_subpath = _normalize_subpath(parsed_subpath)
+        elif parsed_subpath is not None:
+            normalized_subpath = _normalize_subpath(parsed_subpath)
+        else:
+            normalized_subpath = source.subpath
 
         if target_name != name:
             for item in self.config.playlist:
@@ -526,10 +650,23 @@ class MediaManager:
     def scan_directory(self, source: MediaSource, base_path: Optional[str] = None) -> List[PlaylistItem]:
         items: List[PlaylistItem] = []
         source_root = pathlib.Path(source.path)
-        subpath = base_path
-        if not subpath:
-            subpath = source.subpath
-        normalized = _normalize_subpath(subpath)
+        normalized = _normalize_subpath(base_path)
+        configured = _normalize_subpath(source.subpath)
+
+        if normalized:
+            parts = [part for part in normalized.split("/") if part]
+            if configured:
+                configured_parts = [part for part in configured.split("/") if part]
+                if not (
+                    len(parts) >= len(configured_parts)
+                    and [part.lower() for part in parts[: len(configured_parts)]]
+                    == [part.lower() for part in configured_parts]
+                ):
+                    parts = configured_parts + parts
+            normalized = "/".join(parts)
+        else:
+            normalized = configured
+
         base = source_root / pathlib.Path(normalized) if normalized else source_root
         if not base.exists():
             LOGGER.warning("Verzeichnis %s existiert nicht", base)
@@ -575,9 +712,13 @@ class MediaManager:
         return items
 
     def build_playlist(self) -> List[PlaylistItem]:
-        manual_items = list(self.config.playlist)
+        disabled = self._disabled_media_pairs()
+        manual_items = [
+            item for item in self.config.playlist if (item.source, item.path) not in disabled
+        ]
         auto_items: List[PlaylistItem] = []
         seen = {(item.source, item.path) for item in manual_items}
+        seen.update(disabled)
         for source in self.config.media_sources:
             if not source.auto_scan:
                 continue
@@ -621,6 +762,7 @@ class MediaManager:
     ) -> tuple[List[PlaylistItem], List[PlaylistItem]]:
         left_items: List[PlaylistItem] = []
         right_items: List[PlaylistItem] = []
+        disabled = self._disabled_media_pairs()
 
         if left_source:
             source = self.config.get_source(left_source)
@@ -630,17 +772,12 @@ class MediaManager:
                 except Exception as exc:  # pragma: no cover - defensive
                     LOGGER.warning("Konnte linke Quelle %s nicht mounten: %s", left_source, exc)
                 else:
-                    base = left_path or None
-                    if base and source.subpath:
-                        base = "/".join(
-                            part
-                            for part in (
-                                _normalize_subpath(source.subpath),
-                                _normalize_subpath(base),
-                            )
-                            if part
-                        )
-                    left_items = self.scan_directory(source, base)
+                    base = self._normalize_split_base(source, left_path)
+                    left_items = [
+                        item
+                        for item in self.scan_directory(source, base)
+                        if (item.source, item.path) not in disabled
+                    ]
             else:
                 LOGGER.warning("Linke Quelle %s unbekannt", left_source)
 
@@ -652,17 +789,12 @@ class MediaManager:
                 except Exception as exc:  # pragma: no cover - defensive
                     LOGGER.warning("Konnte rechte Quelle %s nicht mounten: %s", right_source, exc)
                 else:
-                    base = right_path or None
-                    if base and source.subpath:
-                        base = "/".join(
-                            part
-                            for part in (
-                                _normalize_subpath(source.subpath),
-                                _normalize_subpath(base),
-                            )
-                            if part
-                        )
-                    right_items = self.scan_directory(source, base)
+                    base = self._normalize_split_base(source, right_path)
+                    right_items = [
+                        item
+                        for item in self.scan_directory(source, base)
+                        if (item.source, item.path) not in disabled
+                    ]
             else:
                 LOGGER.warning("Rechte Quelle %s unbekannt", right_source)
 

--- a/slideshow/static/img/video-placeholder.svg
+++ b/slideshow/static/img/video-placeholder.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90" role="img" aria-labelledby="title desc">
+  <title id="title">Video Platzhalter</title>
+  <desc id="desc">Symbolische Wiedergabeanzeige mit einem Play-Icon</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f3b6d" />
+      <stop offset="100%" stop-color="#0f1f3a" />
+    </linearGradient>
+    <linearGradient id="play" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#cfd6ff" stop-opacity="0.9" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="160" height="90" rx="8" fill="url(#bg)" />
+  <rect x="12" y="16" width="136" height="58" rx="6" fill="#121d33" stroke="#2f4370" stroke-width="2" />
+  <polygon points="70,45 70,35 90,45 70,55" fill="url(#play)" />
+  <circle cx="140" cy="22" r="4" fill="#ff7a45" />
+  <circle cx="150" cy="22" r="4" fill="#ffd166" />
+  <circle cx="130" cy="22" r="4" fill="#06d6a0" />
+</svg>

--- a/slideshow/static/style.css
+++ b/slideshow/static/style.css
@@ -226,6 +226,20 @@ article h2 {
   display: block;
 }
 
+.status-preview__fallback {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  background: var(--surface-alt);
+  padding: 1rem;
+}
+
+.status-preview__fallback[hidden] {
+  display: none;
+}
+
 .status-preview__placeholder {
   position: absolute;
   inset: 0;
@@ -454,6 +468,39 @@ form {
   margin: 0 0 0.5rem 0;
 }
 
+
+.playlist-selection td:first-child {
+  text-align: center;
+  vertical-align: middle;
+}
+
+.playlist-selection input[type="checkbox"] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.playlist-actions {
+  margin-top: 0.75rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+table tr.playlist-disabled {
+  opacity: 0.55;
+}
+
+table tr.playlist-disabled td {
+  color: var(--muted);
+}
+
+.playlist-preview__split h3 {
+  margin-top: 0;
+}
+
+.playlist-preview__split .table-wrapper {
+  margin-top: 0.5rem;
+}
+
 .split-ratio {
   display: flex;
   flex-direction: column;
@@ -479,6 +526,18 @@ form {
 
 .checkbox input[type="checkbox"] {
   width: auto;
+}
+
+.resolution-picker {
+  display: grid;
+  gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .resolution-picker {
+    grid-template-columns: minmax(200px, 1fr) minmax(160px, 0.8fr);
+    align-items: center;
+  }
 }
 
 .muted {
@@ -531,6 +590,12 @@ form {
   border-radius: 0.5rem;
   border: 1px solid rgba(255, 255, 255, 0.2);
   background: rgba(15, 23, 42, 0.6);
+}
+
+.playlist-preview--video {
+  object-fit: contain;
+  background: rgba(15, 23, 42, 0.8);
+  padding: 0.25rem;
 }
 
 .status-block p strong {

--- a/slideshow/templates/dashboard.html
+++ b/slideshow/templates/dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'layout.html' %}
+{% set video_placeholder = url_for('static', filename='img/video-placeholder.svg') %}
 {% block title %}Übersicht – Slideshow{% endblock %}
 {% block content %}
 <section class="grid overview-grid">
@@ -21,6 +22,7 @@
       <div class="status-preview" data-preview="primary">
         <div class="status-preview__frame">
           <img data-preview-image="primary" src="{{ url_for('state_preview', side='primary') }}" alt="Vorschau primäre Anzeige" hidden />
+          <img data-preview-video="primary" src="{{ video_placeholder }}" alt="Video wird abgespielt" class="status-preview__fallback" hidden />
           <span data-preview-placeholder="primary" class="status-preview__placeholder">Keine Vorschau verfügbar</span>
         </div>
       </div>
@@ -35,6 +37,7 @@
       <div class="status-preview" data-preview="secondary">
         <div class="status-preview__frame">
           <img data-preview-image="secondary" src="{{ url_for('state_preview', side='secondary') }}" alt="Vorschau sekundäre Anzeige" hidden />
+          <img data-preview-video="secondary" src="{{ video_placeholder }}" alt="Video wird abgespielt" class="status-preview__fallback" hidden />
           <span data-preview-placeholder="secondary" class="status-preview__placeholder">Keine Vorschau verfügbar</span>
         </div>
       </div>
@@ -47,41 +50,160 @@
 
   <article>
     <h2>Playlist-Vorschau</h2>
-    <p class="muted">Die Wiedergabe wird automatisch aus allen aktiv überwachten Quellen aufgebaut. Neu hinzugefügte Dateien werden nach kurzer Zeit ohne manuelle Eingriffe angezeigt.</p>
-    <div class="table-wrapper">
-      <table>
-        <thead>
-          <tr>
-            <th>#</th>
-            <th>Vorschau</th>
-            <th>Datei</th>
-            <th>Quelle</th>
-            <th>Typ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for item in playlist %}
-          <tr>
-            <td>{{ loop.index }}</td>
-            <td>
-              {% if item.type == 'image' %}
-              <img class="playlist-preview" src="{{ url_for('media_preview', source=item.source, media_path=item.path) }}" alt="Vorschau von {{ item.path }}" loading="lazy" />
-              {% else %}
-              <span class="muted">—</span>
-              {% endif %}
-            </td>
-            <td>{{ item.path }}</td>
-            <td>{{ item.source }}</td>
-            <td>{{ item.type }}</td>
-          </tr>
-          {% else %}
-          <tr>
-            <td colspan="5">Keine Medien gefunden. Bitte prüfen, ob die Quellen erreichbar sind.</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+    {% if config.playback.splitscreen_enabled %}
+    <form method="post" action="{{ url_for('update_playlist_selection') }}" class="playlist-selection">
+      <input type="hidden" name="next" value="{{ url_for('dashboard') }}" />
+      <p class="muted">Die Splitscreen-Wiedergabe nutzt getrennte Listen. Die linke bzw. rechte Seite berücksichtigt jeweils den gewählten Unterordner. Über den Button „Auswahl speichern“ werden Änderungen an den Checkboxen übernommen.</p>
+      <div class="split-grid playlist-preview__split">
+        <div>
+          <h3>Linke Seite</h3>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Anzeigen</th>
+                  <th>#</th>
+                  <th>Vorschau</th>
+                  <th>Datei</th>
+                  <th>Quelle</th>
+                  <th>Typ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in splitscreen_left %}
+                {% set key = item.source ~ '|' ~ item.path %}
+                {% set is_disabled = key in disabled_keys %}
+                <tr class="{% if is_disabled %}playlist-disabled{% endif %}">
+                  <td>
+                    <input type="hidden" name="all_media" value="{{ key }}" />
+                    <input type="checkbox" name="enabled_media" value="{{ key }}" {% if not is_disabled %}checked{% endif %} title="{{ 'Medien anzeigen' if is_disabled else 'Medien ausblenden' }}" />
+                  </td>
+                  <td>{{ loop.index }}</td>
+                  <td>
+                    {% if item.type == 'image' %}
+                    <img class="playlist-preview" src="{{ url_for('media_preview', source=item.source, media_path=item.path) }}" alt="Vorschau von {{ item.path }}" loading="lazy" />
+                    {% elif item.type == 'video' %}
+                    <img class="playlist-preview playlist-preview--video" src="{{ video_placeholder }}" alt="Video Platzhalter" loading="lazy" />
+                    {% else %}
+                    <span class="muted">—</span>
+                    {% endif %}
+                  </td>
+                  <td>{{ item.path }}</td>
+                  <td>{{ item.source }}</td>
+                  <td>{{ item.type }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                  <td colspan="6">Keine Medien gefunden. Bitte Quellen oder Pfad prüfen.</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <div>
+          <h3>Rechte Seite</h3>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Anzeigen</th>
+                  <th>#</th>
+                  <th>Vorschau</th>
+                  <th>Datei</th>
+                  <th>Quelle</th>
+                  <th>Typ</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for item in splitscreen_right %}
+                {% set key = item.source ~ '|' ~ item.path %}
+                {% set is_disabled = key in disabled_keys %}
+                <tr class="{% if is_disabled %}playlist-disabled{% endif %}">
+                  <td>
+                    <input type="hidden" name="all_media" value="{{ key }}" />
+                    <input type="checkbox" name="enabled_media" value="{{ key }}" {% if not is_disabled %}checked{% endif %} title="{{ 'Medien anzeigen' if is_disabled else 'Medien ausblenden' }}" />
+                  </td>
+                  <td>{{ loop.index }}</td>
+                  <td>
+                    {% if item.type == 'image' %}
+                    <img class="playlist-preview" src="{{ url_for('media_preview', source=item.source, media_path=item.path) }}" alt="Vorschau von {{ item.path }}" loading="lazy" />
+                    {% elif item.type == 'video' %}
+                    <img class="playlist-preview playlist-preview--video" src="{{ video_placeholder }}" alt="Video Platzhalter" loading="lazy" />
+                    {% else %}
+                    <span class="muted">—</span>
+                    {% endif %}
+                  </td>
+                  <td>{{ item.path }}</td>
+                  <td>{{ item.source }}</td>
+                  <td>{{ item.type }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                  <td colspan="6">Keine Medien gefunden. Bitte Quellen oder Pfad prüfen.</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="playlist-actions">
+        <button type="submit">Auswahl speichern</button>
+      </div>
+    </form>
+    {% else %}
+    <form method="post" action="{{ url_for('update_playlist_selection') }}" class="playlist-selection">
+      <input type="hidden" name="next" value="{{ url_for('dashboard') }}" />
+      <p class="muted">Die Wiedergabe wird automatisch aus allen aktiv überwachten Quellen aufgebaut. Neu hinzugefügte Dateien werden nach kurzer Zeit ohne manuelle Eingriffe angezeigt. Über den Button „Auswahl speichern“ lassen sich einzelne Medien dauerhaft ausblenden.</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Anzeigen</th>
+              <th>#</th>
+              <th>Vorschau</th>
+              <th>Datei</th>
+              <th>Quelle</th>
+              <th>Typ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in playlist %}
+            {% set key = item.source ~ '|' ~ item.path %}
+            {% set is_disabled = key in disabled_keys %}
+            <tr class="{% if is_disabled %}playlist-disabled{% endif %}">
+              <td>
+                <input type="hidden" name="all_media" value="{{ key }}" />
+                <input type="checkbox" name="enabled_media" value="{{ key }}" {% if not is_disabled %}checked{% endif %} title="{{ 'Medien anzeigen' if is_disabled else 'Medien ausblenden' }}" />
+              </td>
+              <td>{{ loop.index }}</td>
+              <td>
+                {% if item.type == 'image' %}
+                <img class="playlist-preview" src="{{ url_for('media_preview', source=item.source, media_path=item.path) }}" alt="Vorschau von {{ item.path }}" loading="lazy" />
+                {% elif item.type == 'video' %}
+                <img class="playlist-preview playlist-preview--video" src="{{ video_placeholder }}" alt="Video Platzhalter" loading="lazy" />
+                {% else %}
+                <span class="muted">—</span>
+                {% endif %}
+              </td>
+              <td>{{ item.path }}</td>
+              <td>{{ item.source }}</td>
+              <td>{{ item.type }}</td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="6">Keine Medien gefunden. Bitte prüfen, ob die Quellen erreichbar sind.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="playlist-actions">
+        <button type="submit">Auswahl speichern</button>
+      </div>
+    </form>
+    {% endif %}
     <a class="button-link" href="{{ url_for('media_settings') }}">Quellen verwalten</a>
   </article>
 </section>
@@ -120,6 +242,10 @@
       primary: "{{ url_for('state_preview', side='primary') }}",
       secondary: "{{ url_for('state_preview', side='secondary') }}",
     };
+    const previewVideoFallbacks = {
+      primary: document.querySelector('[data-preview-video="primary"]'),
+      secondary: document.querySelector('[data-preview-video="secondary"]'),
+    };
     const formatter = new Intl.DateTimeFormat('de-DE', {
       day: '2-digit',
       month: '2-digit',
@@ -152,6 +278,7 @@
     function updatePreview(side, available, token, mediaType) {
       const image = previewImages[side];
       const placeholder = previewPlaceholders[side];
+      const videoFallback = previewVideoFallbacks[side];
       if (!image || !placeholder) {
         return;
       }
@@ -159,10 +286,20 @@
         image.hidden = false;
         image.src = `${previewUrls[side]}?t=${token || 0}`;
         placeholder.hidden = true;
+        if (videoFallback) {
+          videoFallback.hidden = true;
+        }
+      } else if (mediaType === 'video' && videoFallback) {
+        image.hidden = true;
+        placeholder.hidden = true;
+        videoFallback.hidden = false;
       } else {
         image.hidden = true;
         placeholder.hidden = false;
-        placeholder.textContent = mediaType === 'video' ? 'Video in Wiedergabe' : 'Keine Vorschau verfügbar';
+        placeholder.textContent = 'Keine Vorschau verfügbar';
+        if (videoFallback) {
+          videoFallback.hidden = true;
+        }
       }
     }
 

--- a/slideshow/templates/edit_source.html
+++ b/slideshow/templates/edit_source.html
@@ -11,7 +11,7 @@
       </label>
       <label>SMB-Pfad (optional)
         <input type="text" name="smb_path" placeholder="\\server\freigabe\unterordner" value="{{ request.form.get('smb_path', smb_prefill) }}" />
-        <small class="muted">Optionaler Gesamtpfad zur Freigabe, z. B. <code>smb://server/share/ordner</code>.</small>
+        <small class="muted">Optionaler Gesamtpfad zur Freigabe im UNC-Format, z. B. <code>\\server\freigabe\ordner</code>.</small>
       </label>
       <label>Server
         <input type="text" name="server" value="{{ request.form.get('server', source.options.get('server', '')) }}" />

--- a/slideshow/templates/media.html
+++ b/slideshow/templates/media.html
@@ -88,7 +88,7 @@
       </label>
       <button type="submit">Quelle speichern</button>
     </form>
-    <p class="muted">Die Pfadangabe darf optional Unterordner enthalten (z.&nbsp;B. <code>\\\\server\\share\\bilder</code>); sie werden automatisch erkannt.</p>
+    <p class="muted">Die Pfadangabe darf optional Unterordner enthalten (z.&nbsp;B. <code>\\\\server\\share\\bilder</code>) und sollte im UNC-Format erfolgen; Unterordner werden automatisch erkannt.</p>
   </article>
 </section>
 {% endblock %}

--- a/slideshow/templates/playback.html
+++ b/slideshow/templates/playback.html
@@ -56,8 +56,26 @@
       <label>Übergangsdauer (Sekunden)
         <input type="number" step="0.1" min="0.2" max="10" name="transition_duration" value="{{ config.playback.transition_duration }}" />
       </label>
+      {% set current_resolution = config.playback.display_resolution %}
+      {% set show_custom = current_resolution not in resolution_values and (not detected_resolution or current_resolution != detected_resolution) %}
       <label>Anzeigeauflösung
-        <input type="text" name="display_resolution" value="{{ config.playback.display_resolution }}" />
+        <div class="resolution-picker">
+          <select name="display_resolution_choice" id="display-resolution-choice">
+            {% if detected_resolution and detected_resolution not in resolution_values %}
+            <option value="{{ detected_resolution }}" {% if current_resolution == detected_resolution %}selected{% endif %}>{{ detected_resolution }} (erkannt)</option>
+            {% endif %}
+            {% for value, label in display_resolution_choices %}
+            <option value="{{ value }}" {% if current_resolution == value %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+            <option value="custom" {% if show_custom %}selected{% endif %}>Benutzerdefiniert</option>
+          </select>
+          <input type="text" name="display_resolution_custom" id="display-resolution-custom" value="{% if show_custom %}{{ current_resolution }}{% endif %}" placeholder="z. B. 1920x1080" {% if not show_custom %}hidden disabled{% endif %} />
+        </div>
+        {% if detected_resolution %}
+        <small class="muted">Erkannte Auflösung: <strong>{{ detected_resolution }}</strong>. Wähle „Benutzerdefiniert“, um einen anderen Wert einzugeben.</small>
+        {% else %}
+        <small class="muted">Wähle eine passende Auflösung oder nutze „Benutzerdefiniert“ für eigene Werte.</small>
+        {% endif %}
       </label>
       <label>Zusätzliche Video-Argumente
         <textarea name="video_player_args" rows="3" placeholder="z. B. --vo=gpu">{{ config.playback.video_player_args | default([], true) | join('\n') }}</textarea>
@@ -92,6 +110,7 @@
             </label>
             <label>Pfad (optional)
               <input type="text" name="splitscreen_left_path" value="{{ config.playback.splitscreen_left_path }}" />
+              <small class="muted">Relativer Unterordner innerhalb der Quelle, z. B. <code>bilder\\links</code> oder <code>bilder/links</code>.</small>
             </label>
           </div>
           <div>
@@ -106,6 +125,7 @@
             </label>
             <label>Pfad (optional)
               <input type="text" name="splitscreen_right_path" value="{{ config.playback.splitscreen_right_path }}" />
+              <small class="muted">Relativer Unterordner innerhalb der Quelle, z. B. <code>videos\\rechts</code> oder <code>videos/rechts</code>.</small>
             </label>
           </div>
         </div>
@@ -149,6 +169,23 @@
       updateLabel();
     }
     updateVisibility();
+
+    const resolutionChoice = document.getElementById('display-resolution-choice');
+    const resolutionCustom = document.getElementById('display-resolution-custom');
+
+    const updateResolutionVisibility = () => {
+      if (!resolutionChoice || !resolutionCustom) {
+        return;
+      }
+      const useCustom = resolutionChoice.value === 'custom';
+      resolutionCustom.hidden = !useCustom;
+      resolutionCustom.disabled = !useCustom;
+    };
+
+    if (resolutionChoice) {
+      resolutionChoice.addEventListener('change', updateResolutionVisibility);
+      updateResolutionVisibility();
+    }
   })();
 </script>
 {% endblock %}

--- a/slideshow/templates/system.html
+++ b/slideshow/templates/system.html
@@ -8,19 +8,15 @@
     <form method="post" action="{{ url_for('system_update') }}" class="grid-form">
       <label>Branch auswählen
         <select name="branch">
-          {% set displayed = false %}
-          {% for branch in branches %}
-            {% set displayed = true %}
-            <option value="{{ branch }}" {% if current_branch and branch == current_branch %}selected{% endif %}>{{ branch }}</option>
+          {% for branch in branch_choices %}
+          <option value="{{ branch }}" {% if current_branch and branch == current_branch %}selected{% endif %}>{{ branch }}</option>
           {% endfor %}
-          {% if not displayed and current_branch %}
-            <option value="{{ current_branch }}" selected>{{ current_branch }}</option>
-          {% endif %}
         </select>
       </label>
       <button type="submit">Update starten</button>
     </form>
     <p class="muted">Aktueller Branch: <strong>{{ current_branch or 'unbekannt' }}</strong></p>
+    <p class="muted">Der Ablauf wird in <code>update.log</code> protokolliert und kann unten im Bereich „Protokolle“ eingesehen werden.</p>
     {% else %}
     <p class="muted">Git-Updates stehen in dieser Installation nicht zur Verfügung. Stelle sicher, dass das Repository über Git installiert wurde{% if fallback_repo %} oder prüfe die veröffentlichten Versionen unter <a href="https://github.com/{{ fallback_repo }}/branches" target="_blank" rel="noopener">GitHub</a>{% endif %}.</p>
     {% endif %}


### PR DESCRIPTION
## Summary
- replace the per-row playlist toggle forms with a single confirmation form so checkbox changes persist after saving
- add a backend handler that normalizes submitted media keys, updates the stored disabled list, and reloads the player when selections change
- ensure splitscreen directory scans honor a source's configured subpath when additional folders are entered

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e009b9d0d4832d8531482bc4ba37e8