### PR TITLE
Fix slideshow transition flicker and timing

### DIFF
--- a/slideshow/player.py
+++ b/slideshow/player.py
@@ -552,11 +552,16 @@ class PlayerService:
         display_label: Optional[str] = None,
         media_type: Optional[str] = None,
     ) -> None:
-        duration = max(1, int(duration))
+        requested_duration = max(1.0, float(duration))
         processed_path, _ = self._prepare_image(path, side)
 
         previous = self._previous_images.get(side)
-        self._play_transition(previous, processed_path, side=side, geometry=geometry)
+        transition_duration, transition_file = self._play_transition(
+            previous, processed_path, side=side, geometry=geometry
+        )
+        display_duration = requested_duration
+        if transition_duration > 0:
+            display_duration = max(1.0, requested_duration - transition_duration)
         if previous and previous != processed_path and self._is_temp_file(previous):
             self._safe_remove(previous)
 
@@ -593,10 +598,12 @@ class PlayerService:
             if not controller:
                 LOGGER.error("mpv-Controller für %s nicht verfügbar", side)
             else:
-                controller.set_property("image-display-duration", duration)
+                controller.set_property("image-display-duration", display_duration)
                 hold_for_info = media_kind == "info"
                 if controller.load_file(processed_path):
-                    end_time = time.time() + duration
+                    if transition_file:
+                        self._safe_remove(transition_file)
+                    end_time = time.time() + display_duration
                     interrupted = False
                     while time.time() < end_time:
                         if self._should_interrupt():
@@ -609,6 +616,8 @@ class PlayerService:
                             controller.set_property("pause", True)
                         except Exception:
                             LOGGER.debug("Konnte mpv nicht pausieren, um Infobildschirm zu halten")
+                elif transition_file:
+                    self._safe_remove(transition_file)
         elif viewer == "feh":
             cmd = [
                 viewer,
@@ -616,13 +625,17 @@ class PlayerService:
                 "--fullscreen",
                 "--auto-zoom",
                 "--slideshow-delay",
-                str(duration),
+                str(display_duration),
                 "--cycle-once",
                 str(processed_path),
             ]
             subprocess.run(cmd, check=False)
+            if transition_file:
+                self._safe_remove(transition_file)
         else:
             subprocess.run([viewer, str(processed_path)], check=False)
+            if transition_file:
+                self._safe_remove(transition_file)
         set_state(
             label,
             end_status,
@@ -647,15 +660,15 @@ class PlayerService:
         *,
         side: str,
         geometry: Optional[str],
-    ) -> None:
+    ) -> Tuple[float, Optional[pathlib.Path]]:
         transition_type = (self.config.playback.transition_type or "none").lower()
         if transition_type == "none" or not previous or not previous.exists():
-            return
+            return 0.0, None
         duration = max(0.2, float(self.config.playback.transition_duration))
         ffmpeg = shutil.which("ffmpeg")
         if not ffmpeg:
             LOGGER.warning("Übergang %s übersprungen, ffmpeg nicht gefunden", transition_type)
-            return
+            return 0.0, None
 
         transition_map = {
             "fade": "fade",
@@ -673,7 +686,7 @@ class PlayerService:
         transition = transition_map.get(transition_type)
         if not transition:
             LOGGER.warning("Unbekannter Übergangstyp: %s", transition_type)
-            return
+            return 0.0, None
 
         output = self._temp_dir / f"transition-{side}.mp4"
         cmd = [
@@ -702,7 +715,7 @@ class PlayerService:
         result = subprocess.run(cmd, check=False)
         if result.returncode != 0 or not output.exists():
             LOGGER.warning("ffmpeg konnte Übergang nicht erzeugen")
-            return
+            return 0.0, None
 
         controller = None
         if self._uses_mpv():
@@ -711,6 +724,9 @@ class PlayerService:
             finished = controller.wait_until_idle(self._should_interrupt)
             if not finished and self._should_interrupt():
                 controller.stop_playback()
+                self._safe_remove(output)
+                return 0.0, None
+            return duration, output
         else:
             viewer = self.config.playback.video_player
             cmd = [
@@ -724,8 +740,9 @@ class PlayerService:
             cmd.extend(self._mpv_args)
             cmd.extend(self._mpv_geometry_args(geometry))
             cmd.append(str(output))
-            subprocess.run(cmd, check=False)
+            result = subprocess.run(cmd, check=False)
         self._safe_remove(output)
+        return (duration, None) if result.returncode == 0 else (0.0, None)
 
     # Hilfsfunktionen ----------------------------------------------------
     def _prepare_image(self, path: pathlib.Path, side: str) -> Tuple[pathlib.Path, bool]:


### PR DESCRIPTION
## Summary
- keep transition video available until the next image is loaded to avoid black flashes
- shorten the active display time of images by the transition duration so the configured timing stays correct

## Testing
- python -m compileall slideshow

------
https://chatgpt.com/codex/tasks/task_e_68e06bcf8968832daae283aad324d1da