### PR TITLE
Keep manual info screen visible

### DIFF
--- a/slideshow/mpv_controller.py
+++ b/slideshow/mpv_controller.py
@@ -151,8 +151,9 @@ class MpvController:
             if self.is_idle():
                 return True
             if self._get_property_bool("eof-reached"):
-                # EOF erreicht – Wiedergabe stoppen, um den Zustand zurückzusetzen.
-                self.stop_playback()
+                # EOF erreicht – mpv behält den letzten Frame bei, bis ein neuer
+                # Befehl eingeht. Kein explizites Stoppen, damit der Bildschirm
+                # sichtbar bleibt.
                 return True
             if self._get_property_bool("pause"):
                 # Bei aktivem keep-open signalisiert pause=True einen Abschluss.


### PR DESCRIPTION
## Summary
- prevent manual info screen playback from being interrupted by the manual-info flag so mpv keeps showing it

## Testing
- python -m compileall slideshow

------
https://chatgpt.com/codex/tasks/task_e_68e06bcf8968832daae283aad324d1da