### PR TITLE
Avoid unnecessary config rewrites and support a runtime data directory

### DIFF
--- a/scripts/system_diagnostics.sh
+++ b/scripts/system_diagnostics.sh
@@ -25,7 +25,12 @@ if [[ -z "$DATA_DIR" ]]; then
   DATA_DIR="$HOME/.slideshow"
 fi
 
-LOG_DIR="$DATA_DIR/logs"
+RUNTIME_DIR="${SLIDESHOW_RUNTIME_DIR:-}"
+if [[ -z "$RUNTIME_DIR" ]]; then
+  RUNTIME_DIR="$DATA_DIR"
+fi
+
+LOG_DIR="$RUNTIME_DIR/logs"
 LOG_FILE="$LOG_DIR/diagnostics.log"
 mkdir -p "$LOG_DIR"
 

--- a/slideshow/config.py
+++ b/slideshow/config.py
@@ -44,7 +44,35 @@ def _determine_data_dir() -> pathlib.Path:
 
 
 DATA_DIR = _determine_data_dir()
-CACHE_DIR = DATA_DIR / "cache"
+
+
+def _determine_runtime_dir() -> pathlib.Path:
+    """Bestimmt das Verzeichnis für flüchtige Laufzeitdaten."""
+
+    env_path = os.environ.get("SLIDESHOW_RUNTIME_DIR")
+    if env_path:
+        candidate = pathlib.Path(env_path).expanduser()
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            LOGGER.warning(
+                "Konnte SLIDESHOW_RUNTIME_DIR %s nicht verwenden: %s – falle auf %s zurück.",
+                candidate,
+                exc,
+                DATA_DIR,
+            )
+        else:
+            return candidate
+
+    return DATA_DIR
+
+
+RUNTIME_DIR = _determine_runtime_dir()
+CACHE_DIR = RUNTIME_DIR / "cache"
+LOG_DIR = RUNTIME_DIR / "logs"
+TMP_DIR = RUNTIME_DIR / "tmp"
+INFO_DIR = RUNTIME_DIR / "info"
+STATE_PATH = RUNTIME_DIR / "state.json"
 CONFIG_PATH = DATA_DIR / "config.yml"
 SECRETS_PATH = DATA_DIR / "secrets.json"
 DEFAULT_CONFIG = {
@@ -453,8 +481,18 @@ class AppConfig:
             "logging": dataclasses.asdict(self.logging),
             "maintenance": dataclasses.asdict(self.maintenance),
         }
+        serialized = yaml.safe_dump(raw, sort_keys=False)
         with _lock:
-            CONFIG_PATH.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+            if CONFIG_PATH.exists():
+                try:
+                    existing = CONFIG_PATH.read_text(encoding="utf-8")
+                except OSError:
+                    existing = None
+                else:
+                    if existing == serialized:
+                        return
+
+            CONFIG_PATH.write_text(serialized, encoding="utf-8")
 
     def refresh(self) -> "AppConfig":
         """Lädt die Konfiguration erneut von der Festplatte."""

--- a/slideshow/info.py
+++ b/slideshow/info.py
@@ -7,9 +7,7 @@ from typing import Iterable, List, Optional, Sequence
 
 from PIL import Image, ImageDraw, ImageFont
 
-from .config import DATA_DIR
-
-INFO_DIR = DATA_DIR / "info"
+from .config import INFO_DIR
 
 
 class InfoScreen:

--- a/slideshow/logging_config.py
+++ b/slideshow/logging_config.py
@@ -8,9 +8,7 @@ import pathlib
 import warnings
 from typing import Dict, Tuple
 
-from .config import DATA_DIR
-
-LOG_DIR = DATA_DIR / "logs"
+from .config import LOG_DIR
 
 LOG_GROUPS = {
     "app": {

--- a/slideshow/media.py
+++ b/slideshow/media.py
@@ -22,6 +22,7 @@ from .config import (
     DATA_DIR,
     MediaSource,
     PlaylistItem,
+    RUNTIME_DIR,
     delete_secret,
     ensure_cache_dir,
     load_secret,
@@ -46,7 +47,7 @@ CACHEABLE_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
 
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 DEFAULT_MOUNT_HELPER = BASE_DIR / "scripts" / "mount_smb.sh"
-MOUNT_ROOT = (DATA_DIR / "mounts").resolve()
+MOUNT_ROOT = (RUNTIME_DIR / "mounts").resolve()
 
 PLAYLIST_CONTEXT_FULLSCREEN = "fullscreen"
 PLAYLIST_CONTEXT_SPLIT_LEFT = "splitscreen_left"

--- a/slideshow/state.py
+++ b/slideshow/state.py
@@ -7,8 +7,7 @@ import time
 from dataclasses import asdict, dataclass
 from typing import Optional
 
-from .config import DATA_DIR
-STATE_PATH = DATA_DIR / "state.json"
+from .config import STATE_PATH
 
 _lock = threading.Lock()
 
@@ -84,7 +83,7 @@ def load_state() -> PlaybackState:
 
 
 def save_state(state: PlaybackState) -> None:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(json.dumps(asdict(state)), encoding="utf-8")
 
 

--- a/slideshow/system.py
+++ b/slideshow/system.py
@@ -22,13 +22,16 @@ LOGGER = logging.getLogger(__name__)
 BASE_DIR = pathlib.Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = BASE_DIR / "scripts"
 try:
-    from .config import DATA_DIR
+    from .config import DATA_DIR, LOG_DIR, RUNTIME_DIR, TMP_DIR
 except ImportError:  # pragma: no cover - Fallback für frühe Initialisierung
     DATA_DIR = pathlib.Path.home() / ".slideshow"
+    RUNTIME_DIR = DATA_DIR
+    LOG_DIR = RUNTIME_DIR / "logs"
+    TMP_DIR = RUNTIME_DIR / "tmp"
 
-UPDATE_LOG = DATA_DIR / "logs" / "update.log"
-DIAGNOSTICS_LOG = DATA_DIR / "logs" / "diagnostics.log"
-SMART_TEST_LOG = DATA_DIR / "logs" / "smart-tests.log"
+UPDATE_LOG = LOG_DIR / "update.log"
+DIAGNOSTICS_LOG = LOG_DIR / "diagnostics.log"
+SMART_TEST_LOG = LOG_DIR / "smart-tests.log"
 
 
 def resolve_hostname() -> str:
@@ -286,6 +289,8 @@ class SystemManager:
             (pathlib.Path("/"), "Root-Dateisystem"),
             (DATA_DIR, "Datenverzeichnis"),
         ]
+        if RUNTIME_DIR != DATA_DIR:
+            disk_targets.append((RUNTIME_DIR, "Laufzeitdaten"))
         seen: Dict[str, bool] = {}
         for target_path, label in disk_targets:
             try:
@@ -510,6 +515,7 @@ class SystemManager:
         header = f"Systemdiagnose gestartet (Modus: {normalized})"
         env = os.environ.copy()
         env.setdefault("SLIDESHOW_DATA_DIR", str(DATA_DIR))
+        env.setdefault("SLIDESHOW_RUNTIME_DIR", str(RUNTIME_DIR))
         description = f"Systemdiagnose gestartet ({normalized})"
         return self._spawn_to_log(
             command,
@@ -758,7 +764,7 @@ class SystemManager:
             LOGGER.debug("Leeres Update-Skript von %s erhalten", url)
             return None
         safe_branch = re.sub(r"[^A-Za-z0-9._-]", "_", branch)
-        tmp_dir = DATA_DIR / "tmp"
+        tmp_dir = TMP_DIR
         try:
             tmp_dir.mkdir(parents=True, exist_ok=True)
         except OSError:


### PR DESCRIPTION
## Summary
- skip rewriting the config file when the serialized content is unchanged to reduce unnecessary writes
- allow moving caches, logs, temporary files, and playback state into an optional SLIDESHOW_RUNTIME_DIR so they can live on tmpfs while keeping config/secrets persistent
- update the diagnostics script and system manager to respect the runtime directory for log handling and disk usage reporting

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69111baf1c30832db6d4503e0d3247f2)